### PR TITLE
Add fix for under/overflow error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,8 @@ Description: Circular / ring buffers in R and C.  There are a couple
     represent different trade-offs.
 License: MIT + file LICENSE
 LazyData: true
-URL: https://github.com/richfitz/ring
-BugReports: https://github.com/richfitz/ring/issues
+URL: https://github.com/mrc-ide/ring
+BugReports: https://github.com/mrc-ide/ring/issues
 Imports:
     R6
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ring
 Title: Circular / Ring Buffers
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com")
 Description: Circular / ring buffers in R and C.  There are a couple

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ring 1.0.2
+
+* Fix crash when reading from rings containing more than 2^31 bytes
+
 # ring 1.0.1
 
 * Several small safety tweaks preventing crashes ([#13](https://github.com/richfitz/ring/issues/13))

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 # ring 1.0.1
 
-* Several small safety tweaks preventing crashes ([#13](https://github.com/richfitz/ring/issues/13))
+* Several small safety tweaks preventing crashes (#13)
 
 # ring 1.0.0 (2017-04-24)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
 [![Linux Build Status](https://travis-ci.org/mrc-ide/ring.svg?branch=master)](https://travis-ci.org/mrc-ide/ring)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/github/richfitz/ring?svg=true)](https://ci.appveyor.com/project/richfitz/ring)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/65fqiibc29iyuij9?svg=true)](https://ci.appveyor.com/project/richfitz/ring-vuer2)
 [![codecov.io](https://codecov.io/github/mrc-ide/ring/coverage.svg?branch=master)](https://codecov.io/github/mrc-ide/ring?branch=master)
 
 > Ring buffers in R and C

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # ring
 
 [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
-[![Linux Build Status](https://travis-ci.org/richfitz/ring.svg?branch=master)](https://travis-ci.org/richfitz/ring)
+[![Linux Build Status](https://travis-ci.org/mrc-ide/ring.svg?branch=master)](https://travis-ci.org/mrc-ide/ring)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/github/richfitz/ring?svg=true)](https://ci.appveyor.com/project/richfitz/ring)
-[![codecov.io](https://codecov.io/github/richfitz/ring/coverage.svg?branch=master)](https://codecov.io/github/richfitz/ring?branch=master)
+[![codecov.io](https://codecov.io/github/mrc-ide/ring/coverage.svg?branch=master)](https://codecov.io/github/mrc-ide/ring?branch=master)
 
 > Ring buffers in R and C
 
-Ring buffers (or circular buffers) are like arrays that seem circular; data is written and read in a first-in-first-out (FIFO) style, but once allocated subsequent writes do not cause memory allocations.  Circular buffers are useful for collecting and processing data streams or for queues (with a fixed maximum size).  I use them to implement a solver for delay differential equations in [dde](https://github.com/richfitz/dde).
+Ring buffers (or circular buffers) are like arrays that seem circular; data is written and read in a first-in-first-out (FIFO) style, but once allocated subsequent writes do not cause memory allocations.  Circular buffers are useful for collecting and processing data streams or for queues (with a fixed maximum size).  I use them to implement a solver for delay differential equations in [dde](https://github.com/mrc-ide/dde).
 
 This package provides two implementations of ring buffers:
 
@@ -26,15 +26,15 @@ Both buffer types will refuse to underflow (return elements beyond those that ha
 
 Depending on your application, these ring buffers may or may not be faster than manually copying data around in vectors.  The benefit of this package rather than doing it by hand is abstracting away a lot of subtle bookkeeping and keeping an inteface that is fairly high level.  However, for C applications, using `ring_buffer_bytes` via the C interface (using `LinkingTo`) is likely to be very fast as it avoids all copies.
 
-See the [reference documentation](https://richfitz.github.io/ring) for details.
+See the [reference documentation](https://mrc-ide.github.io/ring) for details.
 
 ## Usage
 
-See the vignette [online](https://richfitz.github.io/ring/vignettes/ring.html) (the vignette is not currently shipped with the pacakge as installed via `install_github`, though once the package in on CRAN it will be available with `code(vignette("ring"))`.
+See the vignette [online](https://mrc-ide.github.io/ring/vignettes/ring.html) (the vignette is not currently shipped with the pacakge as installed via `install_github`, though once the package in on CRAN it will be available with `code(vignette("ring"))`.
 
-A second [vignette](https://richfitz.github.io/ring/vignettes/ring_applications.html) describes possible data structures using a ring buffer.
+A second [vignette](https://mrc-ide.github.io/ring/vignettes/ring_applications.html) describes possible data structures using a ring buffer.
 
-The reference documentation is also available [online](https://richfitz.github.io/ring), or from the package.
+The reference documentation is also available [online](https://mrc-ide.github.io/ring), or from the package.
 
 ## License
 

--- a/inst/include/ring/ring.c
+++ b/inst/include/ring/ring.c
@@ -6,7 +6,7 @@
 bool ring_buffer_handle_overflow(ring_buffer *buffer, size_t n);
 const data_t * ring_buffer_end(const ring_buffer *buffer);
 data_t * ring_buffer_nextp(ring_buffer *buffer, const data_t *p);
-int imin(int a, int b);
+size_t imin(size_t a, size_t b);
 
 #ifdef RING_USE_STDLIB_ALLOC
 #include <stdlib.h>
@@ -541,7 +541,7 @@ data_t * ring_buffer_nextp(ring_buffer *buffer, const data_t *p) {
   return buffer->data + (p - buffer->data) % ring_buffer_bytes_data(buffer);
 }
 
-int imin(int a, int b) {
+size_t imin(size_t a, size_t b) {
   return a < b ? a : b;
 }
 

--- a/tests/testthat/test-ring-buffer-bytes.R
+++ b/tests/testthat/test-ring-buffer-bytes.R
@@ -1320,3 +1320,15 @@ test_that("ring_buffer_copy, different capacities, overflow 2nd", {
   expect_equal(rb2$read(8),
                tail(bytes1, 8))
 })
+
+test_that("ring_buffer_copy, large buffer, don't crash", {
+  testthat::skip_on_cran()
+  b <- ring_buffer_bytes_typed(2^30, numeric(20))
+  r1 <- runif(20)
+  r2 <- runif(20)
+  r3 <- runif(20)
+  b$push(r1)
+  b$push(r2)
+  b$push(r3)
+  expect_equal(b$read(3), c(r1, r2, r3))
+})

--- a/tests/testthat/test-ring-buffer-bytes.R
+++ b/tests/testthat/test-ring-buffer-bytes.R
@@ -1323,10 +1323,13 @@ test_that("ring_buffer_copy, different capacities, overflow 2nd", {
 
 test_that("ring_buffer_copy, large buffer, don't crash", {
   testthat::skip_on_cran()
-  b <- ring_buffer_bytes_typed(2^30, numeric(20))
-  r1 <- runif(20)
-  r2 <- runif(20)
-  r3 <- runif(20)
+  len <- 34022
+  b <- ring_buffer_bytes_typed(10001, numeric(len))
+  b$size()
+  expect_equal(b$size(TRUE), 8 * len * 10001)
+  r1 <- runif(len)
+  r2 <- runif(len)
+  r3 <- runif(len)
   b$push(r1)
   b$push(r2)
   b$push(r3)

--- a/vignettes/ring.Rmd
+++ b/vignettes/ring.Rmd
@@ -491,7 +491,7 @@ writeLines(c("```c",
 ```
 
 For a complete real-world example of use, see
-[dde](https://github.com/richfitz/dde), which uses a ring buffer to
+[dde](https://github.com/mrc-ide/dde), which uses a ring buffer to
 hold the history of a set of differential equations, and uses that
 to implement delay equations.  Here, the ring buffer means that the
 memory requirements don't grow with the length of running the
@@ -513,7 +513,7 @@ writeLines(c("```c",
 
 ## A nontrivial example
 
-In the [`dde`](https://github.com/richfitz/dde) package (not yet on
+In the [`dde`](https://github.com/mrc-ide/dde) package (not yet on
 CRAN), I use ring buffers to solve delay differential equations
 (DDEs).  To solve these, we need to know the state of the system at
 a series of points in the past.  So at every time step we push the
@@ -532,33 +532,33 @@ around.
 To use `ring` within the `dde` package:
 
 * In the `DESCRIPTION` we [declare a link to
-  `ring`](https://github.com/richfitz/dde/blob/7ebaefd/DESCRIPTION#L14)
+  `ring`](https://github.com/mrc-ide/dde/blob/7ebaefd/DESCRIPTION#L14)
   using the `LinkingTo:` field.
 
 * In the `src` directory, [the contents of `<ring/ring.c>` are
-  included](https://github.com/richfitz/dde/blob/7ebaefd/src/ring.c);
+  included](https://github.com/mrc-ide/dde/blob/7ebaefd/src/ring.c);
   this is possible because of the `LinkingTo` field.  This file now
   includes all the actual ring buffer implementation.
 
 * In
-  [src/dopri.h](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.h#L8)
+  [src/dopri.h](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.h#L8)
   we include `<ring/ring.h>` which allows the ring buffer code to be used
   in any file that includes `dopri.h`.  There is a [data structure
   in this
-  header](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.h#L77-L111)
+  header](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.h#L77-L111)
   that includes within itself a ring buffer to hold the history.
 
 * In
-  [src/dopri.c](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.c)
+  [src/dopri.c](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.c)
   the ring buffer code is actually used:
 
-    - [initialisation](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.c#L48-L50)
-    - [a time is found within the ring buffer](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.c#L694-L719)
-    - [the ring buffer is advanced](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.c#L417)
-    - [the data is freed](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.c#L220)
+    - [initialisation](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.c#L48-L50)
+    - [a time is found within the ring buffer](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.c#L694-L719)
+    - [the ring buffer is advanced](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.c#L417)
+    - [the data is freed](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.c#L220)
 
 * In
-  [src/dopri_5.c](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri_5.c#L109-L119)
+  [src/dopri_5.c](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri_5.c#L109-L119)
   new data is written to the head of the ring buffer, being the
   state of the system at the end of the step.  The history head is
   treated as a big block of contiguous doubles.

--- a/vignettes/src/ring.R
+++ b/vignettes/src/ring.R
@@ -397,7 +397,7 @@ writeLines(c("```c",
              "```"))
 
 ## For a complete real-world example of use, see
-## [dde](https://github.com/richfitz/dde), which uses a ring buffer to
+## [dde](https://github.com/mrc-ide/dde), which uses a ring buffer to
 ## hold the history of a set of differential equations, and uses that
 ## to implement delay equations.  Here, the ring buffer means that the
 ## memory requirements don't grow with the length of running the
@@ -418,7 +418,7 @@ writeLines(c("```c",
 
 ## ## A nontrivial example
 
-## In the [`dde`](https://github.com/richfitz/dde) package (not yet on
+## In the [`dde`](https://github.com/mrc-ide/dde) package (not yet on
 ## CRAN), I use ring buffers to solve delay differential equations
 ## (DDEs).  To solve these, we need to know the state of the system at
 ## a series of points in the past.  So at every time step we push the
@@ -437,33 +437,33 @@ writeLines(c("```c",
 ## To use `ring` within the `dde` package:
 
 ## * In the `DESCRIPTION` we [declare a link to
-##   `ring`](https://github.com/richfitz/dde/blob/7ebaefd/DESCRIPTION#L14)
+##   `ring`](https://github.com/mrc-ide/dde/blob/7ebaefd/DESCRIPTION#L14)
 ##   using the `LinkingTo:` field.
 ##
 ## * In the `src` directory, [the contents of `<ring/ring.c>` are
-##   included](https://github.com/richfitz/dde/blob/7ebaefd/src/ring.c);
+##   included](https://github.com/mrc-ide/dde/blob/7ebaefd/src/ring.c);
 ##   this is possible because of the `LinkingTo` field.  This file now
 ##   includes all the actual ring buffer implementation.
 ##
 ## * In
-##   [src/dopri.h](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.h#L8)
+##   [src/dopri.h](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.h#L8)
 ##   we include `<ring/ring.h>` which allows the ring buffer code to be used
 ##   in any file that includes `dopri.h`.  There is a [data structure
 ##   in this
-##   header](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.h#L77-L111)
+##   header](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.h#L77-L111)
 ##   that includes within itself a ring buffer to hold the history.
 ##
 ## * In
-##   [src/dopri.c](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.c)
+##   [src/dopri.c](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.c)
 ##   the ring buffer code is actually used:
 ##
-##     - [initialisation](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.c#L48-L50)
-##     - [a time is found within the ring buffer](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.c#L694-L719)
-##     - [the ring buffer is advanced](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.c#L417)
-##     - [the data is freed](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri.c#L220)
+##     - [initialisation](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.c#L48-L50)
+##     - [a time is found within the ring buffer](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.c#L694-L719)
+##     - [the ring buffer is advanced](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.c#L417)
+##     - [the data is freed](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri.c#L220)
 ##
 ## * In
-##   [src/dopri_5.c](https://github.com/richfitz/dde/blob/7ebaefd/src/dopri_5.c#L109-L119)
+##   [src/dopri_5.c](https://github.com/mrc-ide/dde/blob/7ebaefd/src/dopri_5.c#L109-L119)
 ##   new data is written to the head of the ring buffer, being the
 ##   state of the system at the end of the step.  The history head is
 ##   treated as a big block of contiguous doubles.


### PR DESCRIPTION
Attempt at fixing the root issue as reported by Charlie on the malaria model. If the ring buffer has more than 2^31 bytes (very large stride and/or very large history) there's an integer cast that breaks everything.

Might not work reliably on 32 bit windows