### PR TITLE
Avoid non-portable print format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Suggests:
     knitr,
     rmarkdown,
     testthat
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
+Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Language: en-GB
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ring
 Title: Circular / Ring Buffers
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# ring 1.0.5
+
+* Avoid platform dependent `sprintf` format code
+
+# ring 1.0.4
+
+* Package can be built with strict R headers on
+
 # ring 1.0.3
 
 * Package DESCRIPTION no longer has a `LazyData` field

--- a/R/ring_buffer_bytes.R
+++ b/R/ring_buffer_bytes.R
@@ -5,7 +5,7 @@
 ##' limitation that any data transfer to or from R will always involve
 ##' copies.
 ##'
-##' In contrast with \code{\link{ring_buffer_env}}, every element of
+##' In contrast with [`ring_buffer_env`], every element of
 ##' this buffer has the same size; this makes it less flexible
 ##' (because you have to decide ahead of time what you will be
 ##' storing), but at the same time this can make using the buffer
@@ -13,44 +13,47 @@
 ##' are storing).
 ##'
 ##' If you want to use this to store fixed-size arrays of integers,
-##' numerics, etc, see \code{\link{ring_buffer_bytes_typed}} which
+##' numerics, etc, see [`ring_buffer_bytes_typed`] which
 ##' wraps this with fast conversion functions.
 ##'
-##' If the \code{on_overflow} action is \code{"grow"} and the buffer
-##' overflows, then the size of the buffer will grow geometrically
-##' (this is also the case if you manually \code{$grow()} the buffer
-##' with \code{exact = FALSE}).  When used this way, let \code{n} is
-##' the number of \emph{additional} elements that space is needed for;
-##' \code{ring} then looks at the total needed capacity (used plus
-##' \code{n} relative to \code{size()}).  \emph{If} the buffer needs
-##' to be made larger to fit \code{n} elements in then it is grown by
-##' a factor of phi (the golden ratio, approximately 1.6).  So if to
-##' fit \code{n} elements in the buffer needs to be increased in size
-##' by \code{m} then the smallest of \code{size * phi}, \code{size *
-##' phi^2}, \code{size * phi^3}, ... will be used as the new size.
+##' If the `on_overflow` action is `"grow"` and the buffer overflows,
+##' then the size of the buffer will grow geometrically (this is also
+##' the case if you manually `$grow()` the buffer with `exact =
+##' FALSE`.  When used this way, let `n` is the number of *additional*
+##' elements that space is needed for; `ring` then looks at the total
+##' needed capacity (used plus `n` relative to `size()`).  *If* the
+##' buffer needs to be made larger to fit `n` elements in then it is
+##' grown by a factor of phi (the golden ratio, approximately 1.6).
+##' So if to fit `n` elements in the buffer needs to be increased in
+##' size by `m` then the smallest of `size * phi`, `size * phi^2`,
+##' `size * phi^3`, ... will be used as the new size.
 ##'
-##' In contrast, using the \code{grow()} method with \code{exact =
-##' TRUE} will \emph{always} increase the size of the buffer so long
-##' as \code{n} is positive.
+##' In contrast, using the `grow()` method with `exact = TRUE` will
+##' *always* increase the size of the buffer so long as `n` is
+##' positive.
 ##'
 ##' @template ring_ref
 ##'
 ##' @title Byte array based ring buffer
+##'
 ##' @param size Number of elements in the buffer, each of which will
-##'   be \code{stride} bytes long.
+##'   be `stride` bytes long.
+##'
 ##' @param stride Number of bytes per buffer element.  Defaults to 1
 ##'   byte.  If you want to store anything other than a bytestream in
 ##'   the buffer, you will probably want more than one byte per
 ##'   element; for example, on most R platforms an integer takes 4
-##'   bytes and a double takes 8 (see \code{\link{.Machine}}, and also
-##'   \code{\link{ring_buffer_bytes_typed}}).
+##'   bytes and a double takes 8 (see [`.Machine`], and also
+##'   [`ring_buffer_bytes_typed`]).
+##'
 ##' @param on_overflow Behaviour on buffer overflow.  The default is
 ##'   to overwrite the oldest elements in the buffer
-##'   (\code{"overwrite"}).  Alternative actions are \code{"error"}
+##'   (`"overwrite"`).  Alternative actions are `"error"`
 ##'   which will throw an error if a function tries to add more
-##'   elements than there are space for, or \code{"grow"} which will
+##'   elements than there are space for, or `"grow"` which will
 ##'   grow the buffer to accept the new elements (this uses an
 ##'   approximately golden ratio approach; see details below).
+##'
 ##' @export
 ##' @examples
 ##' # Create a ring buffer of 100 bytes
@@ -204,10 +207,10 @@ R6_ring_buffer_bytes <- R6::R6Class(
     }
   ))
 
-##' This ring buffer is based on \code{\link{ring_buffer_bytes}} but
+##' This ring buffer is based on [ring_buffer_bytes] but
 ##' performs conversion to/from bytes to something useful as data is
 ##' stored/retrieved from the buffer.  This is the interface through
-##' which \code{\link{ring_buffer_bytes_typed}} is implemented.
+##' which [ring_buffer_bytes_typed] is implemented.
 ##'
 ##' The idea here is that manually working with raw vectors can get
 ##' tedious, and if you are planning on using a bytes-based buffer
@@ -220,15 +223,15 @@ R6_ring_buffer_bytes <- R6::R6Class(
 ##' @title Translating bytes ring buffer
 ##' @inheritParams ring_buffer_bytes
 ##' @param to Function to convert an R object to a set of exactly
-##'   \code{stride} bytes.  It must take one argument (being an R
+##'   `stride` bytes.  It must take one argument (being an R
 ##'   object) and return a raw vector of a length that is a multiple
-##'   of \code{stride} (including zero).  It may throw an error if it
+##'   of `stride` (including zero).  It may throw an error if it
 ##'   is not possible to convert an object to a bytes vector.
 ##' @param from Function to convert a set of bytes to an R object.  It
 ##'   must take one argument (being a raw vector of a length that is a
-##'   multiple of \code{stride}, including zero).  It should not throw
+##'   multiple of `stride`, including zero).  It should not throw
 ##'   an error as all data added to the buffer will have passed
-##'   through \code{to} on the way in to the buffer.
+##'   through `to` on the way in to the buffer.
 ##' @export
 ##' @author Rich FitzJohn
 ##' @examples

--- a/R/ring_buffer_bytes_typed.R
+++ b/R/ring_buffer_bytes_typed.R
@@ -1,4 +1,4 @@
-##' Create a ring buffer, backed by a \code{\link{ring_buffer_bytes}},
+##' Create a ring buffer, backed by a [`ring_buffer_bytes`],
 ##' where each element corresponds to a fixed-size vector of one of
 ##' R's atomic numeric types (logical, integer, double, and complex).
 ##'
@@ -14,17 +14,21 @@
 ##' @template ring_ref
 ##'
 ##' @title Typed bytes ring buffer
+##'
 ##' @param size The maximum number of elements the buffer can hold.
 ##'   Each element will be multiple bytes long.
-##' @param what Either a vector on the style of \code{\link{vapply}}
-##'   (e.g., \code{integer(4)} to indicate that each element of the
-##'   buffer is a 4-element integer, or the \code{name} of a storage
-##'   mode if \code{len} is also provided.
+##'
+##' @param what Either a vector on the style of [`vapply`] (e.g.,
+##'   `integer(4)` to indicate that each element of the buffer is a
+##'   4-element integer, or the `name` of a storage mode if `len` is
+##'   also provided.
+##'
 ##' @param len If given, then the length of the storage.  If it is
-##'   given, then if \code{length(what)} is zero, the storage mode of
-##'   \code{what} is used as the type.  Otherwise \code{what} is
-##'   interpreted as the \emph{name} of the storage mode (one of
-##'   "logical", "integer", "double" or "complex".
+##'   given, then if `length(what)` is zero, the storage mode of
+##'   `what` is used as the type.  Otherwise `what` is interpreted as
+##'   the *name* of the storage mode (one of "logical", "integer",
+##'   "double" or "complex".
+##'
 ##' @inheritParams ring_buffer_bytes
 ##' @export
 ##' @author Rich FitzJohn

--- a/R/ring_buffer_env.R
+++ b/R/ring_buffer_env.R
@@ -1,25 +1,25 @@
 ##' An environment based ring buffer.  In contrast with
-##' \code{\link{ring_buffer_bytes}}, this ring buffer is truly
+##' [`ring_buffer_bytes`], this ring buffer is truly
 ##' circular, implemented as a doubly linked list that loops back on
 ##' itself.  Each element of the ring buffer can hold an arbitrary R
 ##' object, and no checking is done to make sure that objects are
 ##' similar types; in this way they are most similar to a circular
-##' version of an R \code{\link{list}}.
+##' version of an R [`list`].
 ##'
 ##' When pushing objects onto the buffer, you must be careful about
-##' the \code{iterate} argument.  By default if the object has a
-##' \code{length()} greater than 1 then \code{$push()} will iterate
-##' over the object (equivalent to \code{$push(data[[1]],
-##' iterate=FALSE)}, \code{$push(data[[2]], iterate=FALSE)}, and so
+##' the `iterate` argument.  By default if the object has a
+##' `length()` greater than 1 then `$push()` will iterate
+##' over the object (equivalent to `$push(data[[1]],
+##' iterate=FALSE)`, `$push(data[[2]], iterate=FALSE)`, and so
 ##' on).
 ##'
 ##' For more information and usage examples, see the vignette
-##' (\code{vignette("ring")}).
+##' (`vignette("ring")`).
 ##'
-##' On underflow (and overflow if \code{on_overflow = "error"})
-##' \code{ring} will raise custom exceptions that can be caught
-##' specially by \code{tryCatch}.  These will have class
-##' \code{ring_underflow} (and \code{ring_overflow} for overflow).  This
+##' On underflow (and overflow if `on_overflow = "error"`)
+##' `ring` will raise custom exceptions that can be caught
+##' specially by `tryCatch`.  These will have class
+##' `ring_underflow` (and `ring_overflow` for overflow).  This
 ##' is not supported in the bytes buffer yet.  See the examples for
 ##' usage.
 ##'
@@ -30,9 +30,9 @@
 ##'
 ##' @param on_overflow Behaviour on buffer overflow.  The default is
 ##'   to overwrite the oldest elements in the buffer
-##'   (\code{"overwrite"}).  Alternative actions are \code{"error"}
+##'   (`"overwrite"`).  Alternative actions are `"error"`
 ##'   which will throw an error if a function tries to add more
-##'   elements than there are space for, or \code{"grow"} which will
+##'   elements than there are space for, or `"grow"` which will
 ##'   grow the buffer to accept the new elements.
 ##'
 ##' @template ring_ref

--- a/inst/include/ring/ring.c
+++ b/inst/include/ring/ring.c
@@ -557,8 +557,8 @@ bool ring_buffer_handle_overflow(ring_buffer *buffer, size_t n) {
       break;
 #ifdef USING_R
     case OVERFLOW_ERROR:
-      Rf_error("Buffer overflow (adding %zu elements, but %zu available)",
-               n, ring_buffer_free(buffer, false));
+      Rf_error("Buffer overflow (adding %d elements, but %d available)",
+               (int)n, (int)ring_buffer_free(buffer, false));
       break;
 #endif
     }

--- a/inst/include/ring/ring.c
+++ b/inst/include/ring/ring.c
@@ -557,7 +557,7 @@ bool ring_buffer_handle_overflow(ring_buffer *buffer, size_t n) {
       break;
 #ifdef USING_R
     case OVERFLOW_ERROR:
-      Rf_error("Buffer overflow (adding %d elements, but %d available)",
+      Rf_error("Buffer overflow (adding %zu elements, but %zu available)",
                n, ring_buffer_free(buffer, false));
       break;
 #endif

--- a/man/ring_buffer_bytes.Rd
+++ b/man/ring_buffer_bytes.Rd
@@ -45,22 +45,20 @@ If you want to use this to store fixed-size arrays of integers,
 numerics, etc, see \code{\link{ring_buffer_bytes_typed}} which
 wraps this with fast conversion functions.
 
-If the \code{on_overflow} action is \code{"grow"} and the buffer
-overflows, then the size of the buffer will grow geometrically
-(this is also the case if you manually \code{$grow()} the buffer
-with \code{exact = FALSE}).  When used this way, let \code{n} is
-the number of \emph{additional} elements that space is needed for;
-\code{ring} then looks at the total needed capacity (used plus
-\code{n} relative to \code{size()}).  \emph{If} the buffer needs
-to be made larger to fit \code{n} elements in then it is grown by
-a factor of phi (the golden ratio, approximately 1.6).  So if to
-fit \code{n} elements in the buffer needs to be increased in size
-by \code{m} then the smallest of \code{size * phi}, \code{size *
-phi^2}, \code{size * phi^3}, ... will be used as the new size.
+If the \code{on_overflow} action is \code{"grow"} and the buffer overflows,
+then the size of the buffer will grow geometrically (this is also
+the case if you manually \verb{$grow()} the buffer with \code{exact = FALSE}.  When used this way, let \code{n} is the number of \emph{additional}
+elements that space is needed for; \code{ring} then looks at the total
+needed capacity (used plus \code{n} relative to \code{size()}).  \emph{If} the
+buffer needs to be made larger to fit \code{n} elements in then it is
+grown by a factor of phi (the golden ratio, approximately 1.6).
+So if to fit \code{n} elements in the buffer needs to be increased in
+size by \code{m} then the smallest of \code{size * phi}, \code{size * phi^2},
+\code{size * phi^3}, ... will be used as the new size.
 
-In contrast, using the \code{grow()} method with \code{exact =
-TRUE} will \emph{always} increase the size of the buffer so long
-as \code{n} is positive.
+In contrast, using the \code{grow()} method with \code{exact = TRUE} will
+\emph{always} increase the size of the buffer so long as \code{n} is
+positive.
 }
 \section{Methods}{
 
@@ -74,391 +72,399 @@ the differences between implementations will be a bit more apparent.
 
 \describe{
 \item{\code{reset}}{
-  Reset the state of the buffer.  This "zeros" the head and tail pointer (and may or may not actually reset the data) so that the buffer can be used as if fresh.
+Reset the state of the buffer.  This "zeros" the head and tail pointer (and may or may not actually reset the data) so that the buffer can be used as if fresh.
 
-  \emph{Usage:}
-  \code{reset(clear = FALSE)}
+\emph{Usage:}
+\code{reset(clear = FALSE)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{clear}:   Logical, indicating if the memory should also be cleared. Generally this is not necessary, but with environment buffers this can let the garbage collector clean up large elements.  For the bytes buffer this zeros the memory.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{clear}:   Logical, indicating if the memory should also be cleared. Generally this is not necessary, but with environment buffers this can let the garbage collector clean up large elements.  For the bytes buffer this zeros the memory.
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{duplicate}}{
-  Clone the ring buffer, creating a copy.  Copies both the underlying data and the position of the head and tail.
+Clone the ring buffer, creating a copy.  Copies both the underlying data and the position of the head and tail.
 
-  \emph{Usage:}
-  \code{duplicate()}
+\emph{Usage:}
+\code{duplicate()}
 
-  \emph{Return value}:
-  A new ring buffer object
+\emph{Return value}:
+A new ring buffer object
 }
 \item{\code{grow}}{
-  Increase the size of the buffer by \code{n} elements.
+Increase the size of the buffer by \code{n} elements.
 
-  \emph{Usage:}
-  \itemize{
-    \item{bytes, typed: \code{grow(n)}}
-    \item{env: \code{grow(n, exact = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{bytes, typed: \code{grow(n)}}
+\item{env: \code{grow(n, exact = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of additional elements that space should be reserved for (scalar non-negative integer).
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of additional elements that space should be reserved for (scalar non-negative integer).
+}
 
-    \item{\code{exact}:   (For bytes buffer only) Logical scalar indicating if growth should increase the size by \emph{exactly} \code{n} elements (if \code{TRUE}) or so that \emph{at least} \code{n} additional elements will fit (growing the buffer geometrically if needed).
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{exact}:   (For bytes buffer only) Logical scalar indicating if growth should increase the size by \\emph\{exactly\} \code{n} elements (if \code{TRUE}) or so that \\emph\{at least\} \code{n} additional elements will fit (growing the buffer geometrically if needed).
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+}
+
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{size}}{
-  Return the capacity (maximum size) of the ring buffer
+Return the capacity (maximum size) of the ring buffer
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{size()}}
-    \item{bytes, typed: \code{size(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{size()}}
+\item{bytes, typed: \code{size(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{bytes_data}}{
-  Return the total size of the data storage used in this object.
+Return the total size of the data storage used in this object.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \emph{(not supported)}}
-    \item{bytes, typed: \code{bytes_data()}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \emph{(not supported)}}
+\item{bytes, typed: \code{bytes_data()}}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{stride}}{
-  Length of each element in the ring buffer, in bytes.  Only implemented (and meaningful) for the bytes buffer; the environment buffer does not support this function as it makes no sense there.
+Length of each element in the ring buffer, in bytes.  Only implemented (and meaningful) for the bytes buffer; the environment buffer does not support this function as it makes no sense there.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \emph{(not supported)}}
-    \item{bytes, typed: \code{stride()}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \emph{(not supported)}}
+\item{bytes, typed: \code{stride()}}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{used}}{
-  Return the amount of space used in the ring buffer.
+Return the amount of space used in the ring buffer.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{used()}}
-    \item{bytes, typed: \code{used(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{used()}}
+\item{bytes, typed: \code{used(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{free}}{
-  Return the amount of space free in the ring buffer.
+Return the amount of space free in the ring buffer.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{free()}}
-    \item{bytes, typed: \code{free(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{free()}}
+\item{bytes, typed: \code{free(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{is_empty}}{
-  Test if the ring buffer is empty
+Test if the ring buffer is empty
 
-  \emph{Usage:}
-  \code{is_empty()}
+\emph{Usage:}
+\code{is_empty()}
 
-  \emph{Return value}:
-  A scalar logical
+\emph{Return value}:
+A scalar logical
 }
 \item{\code{is_full}}{
-  Test if the ring buffer is full
+Test if the ring buffer is full
 
-  \emph{Usage:}
-  \code{is_full()}
+\emph{Usage:}
+\code{is_full()}
 
-  \emph{Return value}:
-  A scalar logical
+\emph{Return value}:
+A scalar logical
 }
 \item{\code{head_pos}}{
-  Return the number of entries from the "start" of the ring buffer the head is.  This is mostly useful for debugging.
+Return the number of entries from the "start" of the ring buffer the head is.  This is mostly useful for debugging.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{head_pos()}}
-    \item{bytes, typed: \code{head_pos(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{head_pos()}}
+\item{bytes, typed: \code{head_pos(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{tail_pos}}{
-  Return the number of entries from the "start" of the ring buffer the tail is.  This is mostly useful for debugging.
+Return the number of entries from the "start" of the ring buffer the tail is.  This is mostly useful for debugging.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{tail_pos()}}
-    \item{bytes, typed: \code{tail_pos(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{tail_pos()}}
+\item{bytes, typed: \code{tail_pos(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{head}}{
-  Return the contents of the head (the most recently written element in the ring buffer).
+Return the contents of the head (the most recently written element in the ring buffer).
 
-  \emph{Usage:}
-  \code{head()}
+\emph{Usage:}
+\code{head()}
 
-  \emph{Return value}:
-  It depends a little here.  For \code{ring_buffer_env} this is a single R object.  For \code{ring_buffer_bytes} it is a raw vector, the same length as the stride of the ring buffer.  For \code{ring_buffer_bytes_typed}, a single R object that has been translated from raw.
+\emph{Return value}:
+It depends a little here.  For \code{ring_buffer_env} this is a single R object.  For \code{ring_buffer_bytes} it is a raw vector, the same length as the stride of the ring buffer.  For \code{ring_buffer_bytes_typed}, a single R object that has been translated from raw.
 }
 \item{\code{tail}}{
-  Return the contents of the tail (the least recently written element in the ring buffer).
+Return the contents of the tail (the least recently written element in the ring buffer).
 
-  \emph{Usage:}
-  \code{tail()}
+\emph{Usage:}
+\code{tail()}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{set}}{
-  Set a number of ring entries to the same value.  The exact behaviour here varies depending on the type of ring buffer.  This function may overflow the ring buffer; in this case the tail will be moved.
+Set a number of ring entries to the same value.  The exact behaviour here varies depending on the type of ring buffer.  This function may overflow the ring buffer; in this case the tail will be moved.
 
-  \emph{Usage:}
-  \code{set(data, n)}
+\emph{Usage:}
+\code{set(data, n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   The data to set each ring element to.  For an environment buffer, this may be any R object.  For a bytes buffer it may be either a single byte (in which case each ring element will be set to that byte, repeated \code{stride} times), or a raw vector of length \code{stride}.
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   The data to set each ring element to.  For an environment buffer, this may be any R object.  For a bytes buffer it may be either a single byte (in which case each ring element will be set to that byte, repeated \code{stride} times), or a raw vector of length \code{stride}.
+}
 
-    \item{\code{n}:   The number of entries to set to \code{data}
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{n}:   The number of entries to set to \code{data}
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  Invisibly returns the number of elements actually written (which may be less than \code{n} if the buffer overflows).  Primarily called for its side effect.
+}
+
+\emph{Return value}:
+Invisibly returns the number of elements actually written (which may be less than \code{n} if the buffer overflows).  Primarily called for its side effect.
 }
 \item{\code{push}}{
-  Push elements onto the ring buffer head.  This may overflow the ring buffer, destroying the oldest elements in the buffer (and moving the position of the tail).
+Push elements onto the ring buffer head.  This may overflow the ring buffer, destroying the oldest elements in the buffer (and moving the position of the tail).
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{push(data, iterate = TRUE)}}
-    \item{bytes, typed: \code{push(data)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{push(data, iterate = TRUE)}}
+\item{bytes, typed: \code{push(data)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   Data to push onto the ring buffer.  For \code{ring_buffer_bytes}, this must be a raw vector with a length that is a multiple of the buffer stride.  For \code{ring_buffer_bytes_typed} it must be a vector of the appropriate type.  For \code{ring_buffer_env} it may be an arbitrary R object (but see \code{iterate} .
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   Data to push onto the ring buffer.  For \code{ring_buffer_bytes}, this must be a raw vector with a length that is a multiple of the buffer stride.  For \code{ring_buffer_bytes_typed} it must be a vector of the appropriate type.  For \code{ring_buffer_env} it may be an arbitrary R object (but see \code{iterate} .
+}
 
-    \item{\code{iterate}:   For \code{ring_buffer_env} only, changes the behaviour with vectors and lists.  Because each element of a \code{ring_buffer_env} can b an arbitrary R object, for a list \code{x} it is ambiguous if \code{push(x)} should push one object onto the buffer, or \code{length(x)} objects (i.e. equivalent to \code{push(x[[1]])}, \code{push(x[[2]])}, etc.  The \code{iterate} argument switches between interpretations; if \code{TRUE} (the default) the push will iterate over the object using \code{for (el in x)} (with appropriate S3 dispatch).  If \code{iterate = FALSE}, then the entire object is pushed at once, so always updating only by a single element.
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{iterate}:   For \code{ring_buffer_env} only, changes the behaviour with vectors and lists.  Because each element of a \code{ring_buffer_env} can b an arbitrary R object, for a list \code{x} it is ambiguous if \code{push(x)} should push one object onto the buffer, or \code{length(x)} objects (i.e. equivalent to \code{push(x[[1]])}, \code{push(x[[2]])}, etc.  The \code{iterate} argument switches between interpretations; if \code{TRUE} (the default) the push will iterate over the object using \code{for (el in x)} (with appropriate S3 dispatch).  If \code{iterate = FALSE}, then the entire object is pushed at once, so always updating only by a single element.
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  For \code{ring_buffer_bytes}, the data invisibly.  For \code{ring_buffer_bytes} and \code{ring_buffer_bytes_typed}, the position of the head pointer (relative to the beginning of the storage region).
+}
+
+\emph{Return value}:
+For \code{ring_buffer_bytes}, the data invisibly.  For \code{ring_buffer_bytes} and \code{ring_buffer_bytes_typed}, the position of the head pointer (relative to the beginning of the storage region).
 }
 \item{\code{take}}{
-  Destructively take elements from the ring buffer.  This consumes from the tail (the least recently added elements).  It is not possibly to underflow the buffer; if more elements are requested than can be supplied then an error will be thrown and the state of the buffer unmodified.
+Destructively take elements from the ring buffer.  This consumes from the tail (the least recently added elements).  It is not possibly to underflow the buffer; if more elements are requested than can be supplied then an error will be thrown and the state of the buffer unmodified.
 
-  \emph{Usage:}
-  \code{take(n)}
+\emph{Usage:}
+\code{take(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of elements to take.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of elements to take.
+}
+}
 
-  \emph{Return value}:
-  For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
+\emph{Return value}:
+For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
 }
 \item{\code{read}}{
-  Nondestructively read elements from the ring buffer.  This is identical to \code{take} except that the state of the buffer is not modified.
+Nondestructively read elements from the ring buffer.  This is identical to \code{take} except that the state of the buffer is not modified.
 
-  \emph{Usage:}
-  \code{read(n)}
+\emph{Usage:}
+\code{read(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of elements to read.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of elements to read.
+}
+}
 
-  \emph{Return value}:
-  For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
+\emph{Return value}:
+For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
 }
 \item{\code{copy}}{
-  Copy from \emph{this} ring buffer into a different ring buffer. This is destructive with respect to both ring buffers; the tail pointer will be moved in this ring buffer as data are taken, and if the destination ring buffer overflows, the tail pointer will be moved too.
+Copy from \emph{this} ring buffer into a different ring buffer. This is destructive with respect to both ring buffers; the tail pointer will be moved in this ring buffer as data are taken, and if the destination ring buffer overflows, the tail pointer will be moved too.
 
-  \emph{Usage:}
-  \code{copy(dest, n)}
+\emph{Usage:}
+\code{copy(dest, n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{dest}:   The destination ring buffer - will be modified by this call.
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{dest}:   The destination ring buffer - will be modified by this call.
+}
 
-    \item{\code{n}:   The number of elements to copy
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{n}:   The number of elements to copy
+\}
+}\if{html}{\out{</div>}}
+
+}
 }
 \item{\code{mirror}}{
-  Mirror the contents of \emph{this} ring buffer into a different ring buffer.  This differs from \code{copy} in that \emph{this} ring buffer is unaffected and in that \emph{all} of this ring buffer is copied over (including head/tail positions).  This provides an alternative way of duplicating state to \code{duplicate} if you already have an appropriately sized ring buffer handy.  No allocations will be done.
+Mirror the contents of \emph{this} ring buffer into a different ring buffer.  This differs from \code{copy} in that \emph{this} ring buffer is unaffected and in that \emph{all} of this ring buffer is copied over (including head/tail positions).  This provides an alternative way of duplicating state to \code{duplicate} if you already have an appropriately sized ring buffer handy.  No allocations will be done.
 
-  \emph{Usage:}
-  \code{mirror(dest)}
+\emph{Usage:}
+\code{mirror(dest)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{dest}:   The destination ring buffer - will be modified by this call.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{dest}:   The destination ring buffer - will be modified by this call.
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{head_offset}}{
-  Nondestructively read the contents of the \code{head} of the buffer, offset by \code{n} entries.
+Nondestructively read the contents of the \code{head} of the buffer, offset by \code{n} entries.
 
-  \emph{Usage:}
-  \code{head_offset(n)}
+\emph{Usage:}
+\code{head_offset(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Head offset.  This moves away from the most recently added item. An offset of 0 reads the most recently added element, 1 reads the element added before that.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Head offset.  This moves away from the most recently added item. An offset of 0 reads the most recently added element, 1 reads the element added before that.
+}
+}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{tail_offset}}{
-  Nondestructively read the contents of the \code{tail} of the buffer, offset by \code{n} entries.
+Nondestructively read the contents of the \code{tail} of the buffer, offset by \code{n} entries.
 
-  \emph{Usage:}
-  \code{tail_offset(n)}
+\emph{Usage:}
+\code{tail_offset(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Tail offset.  This moves away from the oldest item.  An offset of 0 reads the oldest element, 1 reads the element added after that.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Tail offset.  This moves away from the oldest item.  An offset of 0 reads the oldest element, 1 reads the element added after that.
+}
+}
 
-  \emph{Return value}:
-  As for \code{tail} (see \code{head})
+\emph{Return value}:
+As for \code{tail} (see \code{head})
 }
 \item{\code{take_head}}{
-  As for \code{take}, but operating on the head rather than the tail.  This is destructive with respect to the head.
+As for \code{take}, but operating on the head rather than the tail.  This is destructive with respect to the head.
 
-  \emph{Usage:}
-  \code{take_head(n)}
+\emph{Usage:}
+\code{take_head(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Number of elements to take.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Number of elements to take.
+}
+}
 
-  \emph{Return value}:
-  As for \code{take}
+\emph{Return value}:
+As for \code{take}
 }
 \item{\code{read_head}}{
-  As for \code{read}, but operating on the head rather than the tail.  This is not destructive with respect to the tail.
+As for \code{read}, but operating on the head rather than the tail.  This is not destructive with respect to the tail.
 
-  \emph{Usage:}
-  \code{read_head(n)}
+\emph{Usage:}
+\code{read_head(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Number of elements to read.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Number of elements to read.
+}
+}
 
-  \emph{Return value}:
-  As for \code{read}
+\emph{Return value}:
+As for \code{read}
 }
 \item{\code{head_set}}{
-  Set data to the head \emph{without advancing}.  This is useful in cases where the head data will be set and advanced separately (with \code{head_advance}).  This is unlikely to be useful for all users.  It is used extensively in dde (but called from C).
+Set data to the head \emph{without advancing}.  This is useful in cases where the head data will be set and advanced separately (with \code{head_advance}).  This is unlikely to be useful for all users.  It is used extensively in dde (but called from C).
 
-  \emph{Usage:}
-  \code{head_set(data)}
+\emph{Usage:}
+\code{head_set(data)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   Data to set into the head.  For the bytes buffer this must be exactly \code{stride} bytes long, and for the environment buffer it corresponds to a single "element".
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   Data to set into the head.  For the bytes buffer this must be exactly \code{stride} bytes long, and for the environment buffer it corresponds to a single "element".
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{head_data}}{
-  Retrieve the current data stored in the head but not advanced. For many cases this may be junk - if the byte buffer has looped then it will be the bytes that will be overwritten on the next write.  However, when using \code{head_set} it will be the data that have been set into the buffer but not yet committed with \code{head_advance}.
+Retrieve the current data stored in the head but not advanced. For many cases this may be junk - if the byte buffer has looped then it will be the bytes that will be overwritten on the next write.  However, when using \code{head_set} it will be the data that have been set into the buffer but not yet committed with \code{head_advance}.
 
-  \emph{Usage:}
-  \code{head_data()}
+\emph{Usage:}
+\code{head_data()}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{head_advance}}{
-  Shift the head around one position.  This commits any data written by \code{head_set}.
+Shift the head around one position.  This commits any data written by \code{head_set}.
 
-  \emph{Usage:}
-  \code{head_advance()}
+\emph{Usage:}
+\code{head_advance()}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 }
 }

--- a/man/ring_buffer_bytes_translate.Rd
+++ b/man/ring_buffer_bytes_translate.Rd
@@ -38,10 +38,10 @@ grow the buffer to accept the new elements (this uses an
 approximately golden ratio approach; see details below).}
 }
 \description{
-This ring buffer is based on \code{\link{ring_buffer_bytes}} but
+This ring buffer is based on \link{ring_buffer_bytes} but
 performs conversion to/from bytes to something useful as data is
 stored/retrieved from the buffer.  This is the interface through
-which \code{\link{ring_buffer_bytes_typed}} is implemented.
+which \link{ring_buffer_bytes_typed} is implemented.
 }
 \details{
 The idea here is that manually working with raw vectors can get
@@ -63,391 +63,399 @@ the differences between implementations will be a bit more apparent.
 
 \describe{
 \item{\code{reset}}{
-  Reset the state of the buffer.  This "zeros" the head and tail pointer (and may or may not actually reset the data) so that the buffer can be used as if fresh.
+Reset the state of the buffer.  This "zeros" the head and tail pointer (and may or may not actually reset the data) so that the buffer can be used as if fresh.
 
-  \emph{Usage:}
-  \code{reset(clear = FALSE)}
+\emph{Usage:}
+\code{reset(clear = FALSE)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{clear}:   Logical, indicating if the memory should also be cleared. Generally this is not necessary, but with environment buffers this can let the garbage collector clean up large elements.  For the bytes buffer this zeros the memory.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{clear}:   Logical, indicating if the memory should also be cleared. Generally this is not necessary, but with environment buffers this can let the garbage collector clean up large elements.  For the bytes buffer this zeros the memory.
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{duplicate}}{
-  Clone the ring buffer, creating a copy.  Copies both the underlying data and the position of the head and tail.
+Clone the ring buffer, creating a copy.  Copies both the underlying data and the position of the head and tail.
 
-  \emph{Usage:}
-  \code{duplicate()}
+\emph{Usage:}
+\code{duplicate()}
 
-  \emph{Return value}:
-  A new ring buffer object
+\emph{Return value}:
+A new ring buffer object
 }
 \item{\code{grow}}{
-  Increase the size of the buffer by \code{n} elements.
+Increase the size of the buffer by \code{n} elements.
 
-  \emph{Usage:}
-  \itemize{
-    \item{bytes, typed: \code{grow(n)}}
-    \item{env: \code{grow(n, exact = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{bytes, typed: \code{grow(n)}}
+\item{env: \code{grow(n, exact = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of additional elements that space should be reserved for (scalar non-negative integer).
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of additional elements that space should be reserved for (scalar non-negative integer).
+}
 
-    \item{\code{exact}:   (For bytes buffer only) Logical scalar indicating if growth should increase the size by \emph{exactly} \code{n} elements (if \code{TRUE}) or so that \emph{at least} \code{n} additional elements will fit (growing the buffer geometrically if needed).
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{exact}:   (For bytes buffer only) Logical scalar indicating if growth should increase the size by \\emph\{exactly\} \code{n} elements (if \code{TRUE}) or so that \\emph\{at least\} \code{n} additional elements will fit (growing the buffer geometrically if needed).
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+}
+
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{size}}{
-  Return the capacity (maximum size) of the ring buffer
+Return the capacity (maximum size) of the ring buffer
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{size()}}
-    \item{bytes, typed: \code{size(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{size()}}
+\item{bytes, typed: \code{size(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{bytes_data}}{
-  Return the total size of the data storage used in this object.
+Return the total size of the data storage used in this object.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \emph{(not supported)}}
-    \item{bytes, typed: \code{bytes_data()}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \emph{(not supported)}}
+\item{bytes, typed: \code{bytes_data()}}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{stride}}{
-  Length of each element in the ring buffer, in bytes.  Only implemented (and meaningful) for the bytes buffer; the environment buffer does not support this function as it makes no sense there.
+Length of each element in the ring buffer, in bytes.  Only implemented (and meaningful) for the bytes buffer; the environment buffer does not support this function as it makes no sense there.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \emph{(not supported)}}
-    \item{bytes, typed: \code{stride()}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \emph{(not supported)}}
+\item{bytes, typed: \code{stride()}}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{used}}{
-  Return the amount of space used in the ring buffer.
+Return the amount of space used in the ring buffer.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{used()}}
-    \item{bytes, typed: \code{used(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{used()}}
+\item{bytes, typed: \code{used(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{free}}{
-  Return the amount of space free in the ring buffer.
+Return the amount of space free in the ring buffer.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{free()}}
-    \item{bytes, typed: \code{free(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{free()}}
+\item{bytes, typed: \code{free(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{is_empty}}{
-  Test if the ring buffer is empty
+Test if the ring buffer is empty
 
-  \emph{Usage:}
-  \code{is_empty()}
+\emph{Usage:}
+\code{is_empty()}
 
-  \emph{Return value}:
-  A scalar logical
+\emph{Return value}:
+A scalar logical
 }
 \item{\code{is_full}}{
-  Test if the ring buffer is full
+Test if the ring buffer is full
 
-  \emph{Usage:}
-  \code{is_full()}
+\emph{Usage:}
+\code{is_full()}
 
-  \emph{Return value}:
-  A scalar logical
+\emph{Return value}:
+A scalar logical
 }
 \item{\code{head_pos}}{
-  Return the number of entries from the "start" of the ring buffer the head is.  This is mostly useful for debugging.
+Return the number of entries from the "start" of the ring buffer the head is.  This is mostly useful for debugging.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{head_pos()}}
-    \item{bytes, typed: \code{head_pos(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{head_pos()}}
+\item{bytes, typed: \code{head_pos(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{tail_pos}}{
-  Return the number of entries from the "start" of the ring buffer the tail is.  This is mostly useful for debugging.
+Return the number of entries from the "start" of the ring buffer the tail is.  This is mostly useful for debugging.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{tail_pos()}}
-    \item{bytes, typed: \code{tail_pos(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{tail_pos()}}
+\item{bytes, typed: \code{tail_pos(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{head}}{
-  Return the contents of the head (the most recently written element in the ring buffer).
+Return the contents of the head (the most recently written element in the ring buffer).
 
-  \emph{Usage:}
-  \code{head()}
+\emph{Usage:}
+\code{head()}
 
-  \emph{Return value}:
-  It depends a little here.  For \code{ring_buffer_env} this is a single R object.  For \code{ring_buffer_bytes} it is a raw vector, the same length as the stride of the ring buffer.  For \code{ring_buffer_bytes_typed}, a single R object that has been translated from raw.
+\emph{Return value}:
+It depends a little here.  For \code{ring_buffer_env} this is a single R object.  For \code{ring_buffer_bytes} it is a raw vector, the same length as the stride of the ring buffer.  For \code{ring_buffer_bytes_typed}, a single R object that has been translated from raw.
 }
 \item{\code{tail}}{
-  Return the contents of the tail (the least recently written element in the ring buffer).
+Return the contents of the tail (the least recently written element in the ring buffer).
 
-  \emph{Usage:}
-  \code{tail()}
+\emph{Usage:}
+\code{tail()}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{set}}{
-  Set a number of ring entries to the same value.  The exact behaviour here varies depending on the type of ring buffer.  This function may overflow the ring buffer; in this case the tail will be moved.
+Set a number of ring entries to the same value.  The exact behaviour here varies depending on the type of ring buffer.  This function may overflow the ring buffer; in this case the tail will be moved.
 
-  \emph{Usage:}
-  \code{set(data, n)}
+\emph{Usage:}
+\code{set(data, n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   The data to set each ring element to.  For an environment buffer, this may be any R object.  For a bytes buffer it may be either a single byte (in which case each ring element will be set to that byte, repeated \code{stride} times), or a raw vector of length \code{stride}.
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   The data to set each ring element to.  For an environment buffer, this may be any R object.  For a bytes buffer it may be either a single byte (in which case each ring element will be set to that byte, repeated \code{stride} times), or a raw vector of length \code{stride}.
+}
 
-    \item{\code{n}:   The number of entries to set to \code{data}
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{n}:   The number of entries to set to \code{data}
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  Invisibly returns the number of elements actually written (which may be less than \code{n} if the buffer overflows).  Primarily called for its side effect.
+}
+
+\emph{Return value}:
+Invisibly returns the number of elements actually written (which may be less than \code{n} if the buffer overflows).  Primarily called for its side effect.
 }
 \item{\code{push}}{
-  Push elements onto the ring buffer head.  This may overflow the ring buffer, destroying the oldest elements in the buffer (and moving the position of the tail).
+Push elements onto the ring buffer head.  This may overflow the ring buffer, destroying the oldest elements in the buffer (and moving the position of the tail).
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{push(data, iterate = TRUE)}}
-    \item{bytes, typed: \code{push(data)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{push(data, iterate = TRUE)}}
+\item{bytes, typed: \code{push(data)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   Data to push onto the ring buffer.  For \code{ring_buffer_bytes}, this must be a raw vector with a length that is a multiple of the buffer stride.  For \code{ring_buffer_bytes_typed} it must be a vector of the appropriate type.  For \code{ring_buffer_env} it may be an arbitrary R object (but see \code{iterate} .
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   Data to push onto the ring buffer.  For \code{ring_buffer_bytes}, this must be a raw vector with a length that is a multiple of the buffer stride.  For \code{ring_buffer_bytes_typed} it must be a vector of the appropriate type.  For \code{ring_buffer_env} it may be an arbitrary R object (but see \code{iterate} .
+}
 
-    \item{\code{iterate}:   For \code{ring_buffer_env} only, changes the behaviour with vectors and lists.  Because each element of a \code{ring_buffer_env} can b an arbitrary R object, for a list \code{x} it is ambiguous if \code{push(x)} should push one object onto the buffer, or \code{length(x)} objects (i.e. equivalent to \code{push(x[[1]])}, \code{push(x[[2]])}, etc.  The \code{iterate} argument switches between interpretations; if \code{TRUE} (the default) the push will iterate over the object using \code{for (el in x)} (with appropriate S3 dispatch).  If \code{iterate = FALSE}, then the entire object is pushed at once, so always updating only by a single element.
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{iterate}:   For \code{ring_buffer_env} only, changes the behaviour with vectors and lists.  Because each element of a \code{ring_buffer_env} can b an arbitrary R object, for a list \code{x} it is ambiguous if \code{push(x)} should push one object onto the buffer, or \code{length(x)} objects (i.e. equivalent to \code{push(x[[1]])}, \code{push(x[[2]])}, etc.  The \code{iterate} argument switches between interpretations; if \code{TRUE} (the default) the push will iterate over the object using \code{for (el in x)} (with appropriate S3 dispatch).  If \code{iterate = FALSE}, then the entire object is pushed at once, so always updating only by a single element.
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  For \code{ring_buffer_bytes}, the data invisibly.  For \code{ring_buffer_bytes} and \code{ring_buffer_bytes_typed}, the position of the head pointer (relative to the beginning of the storage region).
+}
+
+\emph{Return value}:
+For \code{ring_buffer_bytes}, the data invisibly.  For \code{ring_buffer_bytes} and \code{ring_buffer_bytes_typed}, the position of the head pointer (relative to the beginning of the storage region).
 }
 \item{\code{take}}{
-  Destructively take elements from the ring buffer.  This consumes from the tail (the least recently added elements).  It is not possibly to underflow the buffer; if more elements are requested than can be supplied then an error will be thrown and the state of the buffer unmodified.
+Destructively take elements from the ring buffer.  This consumes from the tail (the least recently added elements).  It is not possibly to underflow the buffer; if more elements are requested than can be supplied then an error will be thrown and the state of the buffer unmodified.
 
-  \emph{Usage:}
-  \code{take(n)}
+\emph{Usage:}
+\code{take(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of elements to take.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of elements to take.
+}
+}
 
-  \emph{Return value}:
-  For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
+\emph{Return value}:
+For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
 }
 \item{\code{read}}{
-  Nondestructively read elements from the ring buffer.  This is identical to \code{take} except that the state of the buffer is not modified.
+Nondestructively read elements from the ring buffer.  This is identical to \code{take} except that the state of the buffer is not modified.
 
-  \emph{Usage:}
-  \code{read(n)}
+\emph{Usage:}
+\code{read(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of elements to read.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of elements to read.
+}
+}
 
-  \emph{Return value}:
-  For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
+\emph{Return value}:
+For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
 }
 \item{\code{copy}}{
-  Copy from \emph{this} ring buffer into a different ring buffer. This is destructive with respect to both ring buffers; the tail pointer will be moved in this ring buffer as data are taken, and if the destination ring buffer overflows, the tail pointer will be moved too.
+Copy from \emph{this} ring buffer into a different ring buffer. This is destructive with respect to both ring buffers; the tail pointer will be moved in this ring buffer as data are taken, and if the destination ring buffer overflows, the tail pointer will be moved too.
 
-  \emph{Usage:}
-  \code{copy(dest, n)}
+\emph{Usage:}
+\code{copy(dest, n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{dest}:   The destination ring buffer - will be modified by this call.
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{dest}:   The destination ring buffer - will be modified by this call.
+}
 
-    \item{\code{n}:   The number of elements to copy
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{n}:   The number of elements to copy
+\}
+}\if{html}{\out{</div>}}
+
+}
 }
 \item{\code{mirror}}{
-  Mirror the contents of \emph{this} ring buffer into a different ring buffer.  This differs from \code{copy} in that \emph{this} ring buffer is unaffected and in that \emph{all} of this ring buffer is copied over (including head/tail positions).  This provides an alternative way of duplicating state to \code{duplicate} if you already have an appropriately sized ring buffer handy.  No allocations will be done.
+Mirror the contents of \emph{this} ring buffer into a different ring buffer.  This differs from \code{copy} in that \emph{this} ring buffer is unaffected and in that \emph{all} of this ring buffer is copied over (including head/tail positions).  This provides an alternative way of duplicating state to \code{duplicate} if you already have an appropriately sized ring buffer handy.  No allocations will be done.
 
-  \emph{Usage:}
-  \code{mirror(dest)}
+\emph{Usage:}
+\code{mirror(dest)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{dest}:   The destination ring buffer - will be modified by this call.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{dest}:   The destination ring buffer - will be modified by this call.
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{head_offset}}{
-  Nondestructively read the contents of the \code{head} of the buffer, offset by \code{n} entries.
+Nondestructively read the contents of the \code{head} of the buffer, offset by \code{n} entries.
 
-  \emph{Usage:}
-  \code{head_offset(n)}
+\emph{Usage:}
+\code{head_offset(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Head offset.  This moves away from the most recently added item. An offset of 0 reads the most recently added element, 1 reads the element added before that.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Head offset.  This moves away from the most recently added item. An offset of 0 reads the most recently added element, 1 reads the element added before that.
+}
+}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{tail_offset}}{
-  Nondestructively read the contents of the \code{tail} of the buffer, offset by \code{n} entries.
+Nondestructively read the contents of the \code{tail} of the buffer, offset by \code{n} entries.
 
-  \emph{Usage:}
-  \code{tail_offset(n)}
+\emph{Usage:}
+\code{tail_offset(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Tail offset.  This moves away from the oldest item.  An offset of 0 reads the oldest element, 1 reads the element added after that.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Tail offset.  This moves away from the oldest item.  An offset of 0 reads the oldest element, 1 reads the element added after that.
+}
+}
 
-  \emph{Return value}:
-  As for \code{tail} (see \code{head})
+\emph{Return value}:
+As for \code{tail} (see \code{head})
 }
 \item{\code{take_head}}{
-  As for \code{take}, but operating on the head rather than the tail.  This is destructive with respect to the head.
+As for \code{take}, but operating on the head rather than the tail.  This is destructive with respect to the head.
 
-  \emph{Usage:}
-  \code{take_head(n)}
+\emph{Usage:}
+\code{take_head(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Number of elements to take.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Number of elements to take.
+}
+}
 
-  \emph{Return value}:
-  As for \code{take}
+\emph{Return value}:
+As for \code{take}
 }
 \item{\code{read_head}}{
-  As for \code{read}, but operating on the head rather than the tail.  This is not destructive with respect to the tail.
+As for \code{read}, but operating on the head rather than the tail.  This is not destructive with respect to the tail.
 
-  \emph{Usage:}
-  \code{read_head(n)}
+\emph{Usage:}
+\code{read_head(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Number of elements to read.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Number of elements to read.
+}
+}
 
-  \emph{Return value}:
-  As for \code{read}
+\emph{Return value}:
+As for \code{read}
 }
 \item{\code{head_set}}{
-  Set data to the head \emph{without advancing}.  This is useful in cases where the head data will be set and advanced separately (with \code{head_advance}).  This is unlikely to be useful for all users.  It is used extensively in dde (but called from C).
+Set data to the head \emph{without advancing}.  This is useful in cases where the head data will be set and advanced separately (with \code{head_advance}).  This is unlikely to be useful for all users.  It is used extensively in dde (but called from C).
 
-  \emph{Usage:}
-  \code{head_set(data)}
+\emph{Usage:}
+\code{head_set(data)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   Data to set into the head.  For the bytes buffer this must be exactly \code{stride} bytes long, and for the environment buffer it corresponds to a single "element".
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   Data to set into the head.  For the bytes buffer this must be exactly \code{stride} bytes long, and for the environment buffer it corresponds to a single "element".
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{head_data}}{
-  Retrieve the current data stored in the head but not advanced. For many cases this may be junk - if the byte buffer has looped then it will be the bytes that will be overwritten on the next write.  However, when using \code{head_set} it will be the data that have been set into the buffer but not yet committed with \code{head_advance}.
+Retrieve the current data stored in the head but not advanced. For many cases this may be junk - if the byte buffer has looped then it will be the bytes that will be overwritten on the next write.  However, when using \code{head_set} it will be the data that have been set into the buffer but not yet committed with \code{head_advance}.
 
-  \emph{Usage:}
-  \code{head_data()}
+\emph{Usage:}
+\code{head_data()}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{head_advance}}{
-  Shift the head around one position.  This commits any data written by \code{head_set}.
+Shift the head around one position.  This commits any data written by \code{head_set}.
 
-  \emph{Usage:}
-  \code{head_advance()}
+\emph{Usage:}
+\code{head_advance()}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 }
 }

--- a/man/ring_buffer_bytes_typed.Rd
+++ b/man/ring_buffer_bytes_typed.Rd
@@ -10,16 +10,16 @@ ring_buffer_bytes_typed(size, what, len = NULL, on_overflow = "overwrite")
 \item{size}{The maximum number of elements the buffer can hold.
 Each element will be multiple bytes long.}
 
-\item{what}{Either a vector on the style of \code{\link{vapply}}
-(e.g., \code{integer(4)} to indicate that each element of the
-buffer is a 4-element integer, or the \code{name} of a storage
-mode if \code{len} is also provided.}
+\item{what}{Either a vector on the style of \code{\link{vapply}} (e.g.,
+\code{integer(4)} to indicate that each element of the buffer is a
+4-element integer, or the \code{name} of a storage mode if \code{len} is
+also provided.}
 
 \item{len}{If given, then the length of the storage.  If it is
 given, then if \code{length(what)} is zero, the storage mode of
-\code{what} is used as the type.  Otherwise \code{what} is
-interpreted as the \emph{name} of the storage mode (one of
-"logical", "integer", "double" or "complex".}
+\code{what} is used as the type.  Otherwise \code{what} is interpreted as
+the \emph{name} of the storage mode (one of "logical", "integer",
+"double" or "complex".}
 
 \item{on_overflow}{Behaviour on buffer overflow.  The default is
 to overwrite the oldest elements in the buffer
@@ -56,391 +56,399 @@ the differences between implementations will be a bit more apparent.
 
 \describe{
 \item{\code{reset}}{
-  Reset the state of the buffer.  This "zeros" the head and tail pointer (and may or may not actually reset the data) so that the buffer can be used as if fresh.
+Reset the state of the buffer.  This "zeros" the head and tail pointer (and may or may not actually reset the data) so that the buffer can be used as if fresh.
 
-  \emph{Usage:}
-  \code{reset(clear = FALSE)}
+\emph{Usage:}
+\code{reset(clear = FALSE)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{clear}:   Logical, indicating if the memory should also be cleared. Generally this is not necessary, but with environment buffers this can let the garbage collector clean up large elements.  For the bytes buffer this zeros the memory.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{clear}:   Logical, indicating if the memory should also be cleared. Generally this is not necessary, but with environment buffers this can let the garbage collector clean up large elements.  For the bytes buffer this zeros the memory.
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{duplicate}}{
-  Clone the ring buffer, creating a copy.  Copies both the underlying data and the position of the head and tail.
+Clone the ring buffer, creating a copy.  Copies both the underlying data and the position of the head and tail.
 
-  \emph{Usage:}
-  \code{duplicate()}
+\emph{Usage:}
+\code{duplicate()}
 
-  \emph{Return value}:
-  A new ring buffer object
+\emph{Return value}:
+A new ring buffer object
 }
 \item{\code{grow}}{
-  Increase the size of the buffer by \code{n} elements.
+Increase the size of the buffer by \code{n} elements.
 
-  \emph{Usage:}
-  \itemize{
-    \item{bytes, typed: \code{grow(n)}}
-    \item{env: \code{grow(n, exact = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{bytes, typed: \code{grow(n)}}
+\item{env: \code{grow(n, exact = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of additional elements that space should be reserved for (scalar non-negative integer).
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of additional elements that space should be reserved for (scalar non-negative integer).
+}
 
-    \item{\code{exact}:   (For bytes buffer only) Logical scalar indicating if growth should increase the size by \emph{exactly} \code{n} elements (if \code{TRUE}) or so that \emph{at least} \code{n} additional elements will fit (growing the buffer geometrically if needed).
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{exact}:   (For bytes buffer only) Logical scalar indicating if growth should increase the size by \\emph\{exactly\} \code{n} elements (if \code{TRUE}) or so that \\emph\{at least\} \code{n} additional elements will fit (growing the buffer geometrically if needed).
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+}
+
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{size}}{
-  Return the capacity (maximum size) of the ring buffer
+Return the capacity (maximum size) of the ring buffer
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{size()}}
-    \item{bytes, typed: \code{size(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{size()}}
+\item{bytes, typed: \code{size(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{bytes_data}}{
-  Return the total size of the data storage used in this object.
+Return the total size of the data storage used in this object.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \emph{(not supported)}}
-    \item{bytes, typed: \code{bytes_data()}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \emph{(not supported)}}
+\item{bytes, typed: \code{bytes_data()}}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{stride}}{
-  Length of each element in the ring buffer, in bytes.  Only implemented (and meaningful) for the bytes buffer; the environment buffer does not support this function as it makes no sense there.
+Length of each element in the ring buffer, in bytes.  Only implemented (and meaningful) for the bytes buffer; the environment buffer does not support this function as it makes no sense there.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \emph{(not supported)}}
-    \item{bytes, typed: \code{stride()}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \emph{(not supported)}}
+\item{bytes, typed: \code{stride()}}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{used}}{
-  Return the amount of space used in the ring buffer.
+Return the amount of space used in the ring buffer.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{used()}}
-    \item{bytes, typed: \code{used(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{used()}}
+\item{bytes, typed: \code{used(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{free}}{
-  Return the amount of space free in the ring buffer.
+Return the amount of space free in the ring buffer.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{free()}}
-    \item{bytes, typed: \code{free(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{free()}}
+\item{bytes, typed: \code{free(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{is_empty}}{
-  Test if the ring buffer is empty
+Test if the ring buffer is empty
 
-  \emph{Usage:}
-  \code{is_empty()}
+\emph{Usage:}
+\code{is_empty()}
 
-  \emph{Return value}:
-  A scalar logical
+\emph{Return value}:
+A scalar logical
 }
 \item{\code{is_full}}{
-  Test if the ring buffer is full
+Test if the ring buffer is full
 
-  \emph{Usage:}
-  \code{is_full()}
+\emph{Usage:}
+\code{is_full()}
 
-  \emph{Return value}:
-  A scalar logical
+\emph{Return value}:
+A scalar logical
 }
 \item{\code{head_pos}}{
-  Return the number of entries from the "start" of the ring buffer the head is.  This is mostly useful for debugging.
+Return the number of entries from the "start" of the ring buffer the head is.  This is mostly useful for debugging.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{head_pos()}}
-    \item{bytes, typed: \code{head_pos(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{head_pos()}}
+\item{bytes, typed: \code{head_pos(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{tail_pos}}{
-  Return the number of entries from the "start" of the ring buffer the tail is.  This is mostly useful for debugging.
+Return the number of entries from the "start" of the ring buffer the tail is.  This is mostly useful for debugging.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{tail_pos()}}
-    \item{bytes, typed: \code{tail_pos(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{tail_pos()}}
+\item{bytes, typed: \code{tail_pos(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{head}}{
-  Return the contents of the head (the most recently written element in the ring buffer).
+Return the contents of the head (the most recently written element in the ring buffer).
 
-  \emph{Usage:}
-  \code{head()}
+\emph{Usage:}
+\code{head()}
 
-  \emph{Return value}:
-  It depends a little here.  For \code{ring_buffer_env} this is a single R object.  For \code{ring_buffer_bytes} it is a raw vector, the same length as the stride of the ring buffer.  For \code{ring_buffer_bytes_typed}, a single R object that has been translated from raw.
+\emph{Return value}:
+It depends a little here.  For \code{ring_buffer_env} this is a single R object.  For \code{ring_buffer_bytes} it is a raw vector, the same length as the stride of the ring buffer.  For \code{ring_buffer_bytes_typed}, a single R object that has been translated from raw.
 }
 \item{\code{tail}}{
-  Return the contents of the tail (the least recently written element in the ring buffer).
+Return the contents of the tail (the least recently written element in the ring buffer).
 
-  \emph{Usage:}
-  \code{tail()}
+\emph{Usage:}
+\code{tail()}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{set}}{
-  Set a number of ring entries to the same value.  The exact behaviour here varies depending on the type of ring buffer.  This function may overflow the ring buffer; in this case the tail will be moved.
+Set a number of ring entries to the same value.  The exact behaviour here varies depending on the type of ring buffer.  This function may overflow the ring buffer; in this case the tail will be moved.
 
-  \emph{Usage:}
-  \code{set(data, n)}
+\emph{Usage:}
+\code{set(data, n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   The data to set each ring element to.  For an environment buffer, this may be any R object.  For a bytes buffer it may be either a single byte (in which case each ring element will be set to that byte, repeated \code{stride} times), or a raw vector of length \code{stride}.
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   The data to set each ring element to.  For an environment buffer, this may be any R object.  For a bytes buffer it may be either a single byte (in which case each ring element will be set to that byte, repeated \code{stride} times), or a raw vector of length \code{stride}.
+}
 
-    \item{\code{n}:   The number of entries to set to \code{data}
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{n}:   The number of entries to set to \code{data}
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  Invisibly returns the number of elements actually written (which may be less than \code{n} if the buffer overflows).  Primarily called for its side effect.
+}
+
+\emph{Return value}:
+Invisibly returns the number of elements actually written (which may be less than \code{n} if the buffer overflows).  Primarily called for its side effect.
 }
 \item{\code{push}}{
-  Push elements onto the ring buffer head.  This may overflow the ring buffer, destroying the oldest elements in the buffer (and moving the position of the tail).
+Push elements onto the ring buffer head.  This may overflow the ring buffer, destroying the oldest elements in the buffer (and moving the position of the tail).
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{push(data, iterate = TRUE)}}
-    \item{bytes, typed: \code{push(data)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{push(data, iterate = TRUE)}}
+\item{bytes, typed: \code{push(data)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   Data to push onto the ring buffer.  For \code{ring_buffer_bytes}, this must be a raw vector with a length that is a multiple of the buffer stride.  For \code{ring_buffer_bytes_typed} it must be a vector of the appropriate type.  For \code{ring_buffer_env} it may be an arbitrary R object (but see \code{iterate} .
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   Data to push onto the ring buffer.  For \code{ring_buffer_bytes}, this must be a raw vector with a length that is a multiple of the buffer stride.  For \code{ring_buffer_bytes_typed} it must be a vector of the appropriate type.  For \code{ring_buffer_env} it may be an arbitrary R object (but see \code{iterate} .
+}
 
-    \item{\code{iterate}:   For \code{ring_buffer_env} only, changes the behaviour with vectors and lists.  Because each element of a \code{ring_buffer_env} can b an arbitrary R object, for a list \code{x} it is ambiguous if \code{push(x)} should push one object onto the buffer, or \code{length(x)} objects (i.e. equivalent to \code{push(x[[1]])}, \code{push(x[[2]])}, etc.  The \code{iterate} argument switches between interpretations; if \code{TRUE} (the default) the push will iterate over the object using \code{for (el in x)} (with appropriate S3 dispatch).  If \code{iterate = FALSE}, then the entire object is pushed at once, so always updating only by a single element.
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{iterate}:   For \code{ring_buffer_env} only, changes the behaviour with vectors and lists.  Because each element of a \code{ring_buffer_env} can b an arbitrary R object, for a list \code{x} it is ambiguous if \code{push(x)} should push one object onto the buffer, or \code{length(x)} objects (i.e. equivalent to \code{push(x[[1]])}, \code{push(x[[2]])}, etc.  The \code{iterate} argument switches between interpretations; if \code{TRUE} (the default) the push will iterate over the object using \code{for (el in x)} (with appropriate S3 dispatch).  If \code{iterate = FALSE}, then the entire object is pushed at once, so always updating only by a single element.
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  For \code{ring_buffer_bytes}, the data invisibly.  For \code{ring_buffer_bytes} and \code{ring_buffer_bytes_typed}, the position of the head pointer (relative to the beginning of the storage region).
+}
+
+\emph{Return value}:
+For \code{ring_buffer_bytes}, the data invisibly.  For \code{ring_buffer_bytes} and \code{ring_buffer_bytes_typed}, the position of the head pointer (relative to the beginning of the storage region).
 }
 \item{\code{take}}{
-  Destructively take elements from the ring buffer.  This consumes from the tail (the least recently added elements).  It is not possibly to underflow the buffer; if more elements are requested than can be supplied then an error will be thrown and the state of the buffer unmodified.
+Destructively take elements from the ring buffer.  This consumes from the tail (the least recently added elements).  It is not possibly to underflow the buffer; if more elements are requested than can be supplied then an error will be thrown and the state of the buffer unmodified.
 
-  \emph{Usage:}
-  \code{take(n)}
+\emph{Usage:}
+\code{take(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of elements to take.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of elements to take.
+}
+}
 
-  \emph{Return value}:
-  For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
+\emph{Return value}:
+For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
 }
 \item{\code{read}}{
-  Nondestructively read elements from the ring buffer.  This is identical to \code{take} except that the state of the buffer is not modified.
+Nondestructively read elements from the ring buffer.  This is identical to \code{take} except that the state of the buffer is not modified.
 
-  \emph{Usage:}
-  \code{read(n)}
+\emph{Usage:}
+\code{read(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of elements to read.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of elements to read.
+}
+}
 
-  \emph{Return value}:
-  For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
+\emph{Return value}:
+For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
 }
 \item{\code{copy}}{
-  Copy from \emph{this} ring buffer into a different ring buffer. This is destructive with respect to both ring buffers; the tail pointer will be moved in this ring buffer as data are taken, and if the destination ring buffer overflows, the tail pointer will be moved too.
+Copy from \emph{this} ring buffer into a different ring buffer. This is destructive with respect to both ring buffers; the tail pointer will be moved in this ring buffer as data are taken, and if the destination ring buffer overflows, the tail pointer will be moved too.
 
-  \emph{Usage:}
-  \code{copy(dest, n)}
+\emph{Usage:}
+\code{copy(dest, n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{dest}:   The destination ring buffer - will be modified by this call.
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{dest}:   The destination ring buffer - will be modified by this call.
+}
 
-    \item{\code{n}:   The number of elements to copy
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{n}:   The number of elements to copy
+\}
+}\if{html}{\out{</div>}}
+
+}
 }
 \item{\code{mirror}}{
-  Mirror the contents of \emph{this} ring buffer into a different ring buffer.  This differs from \code{copy} in that \emph{this} ring buffer is unaffected and in that \emph{all} of this ring buffer is copied over (including head/tail positions).  This provides an alternative way of duplicating state to \code{duplicate} if you already have an appropriately sized ring buffer handy.  No allocations will be done.
+Mirror the contents of \emph{this} ring buffer into a different ring buffer.  This differs from \code{copy} in that \emph{this} ring buffer is unaffected and in that \emph{all} of this ring buffer is copied over (including head/tail positions).  This provides an alternative way of duplicating state to \code{duplicate} if you already have an appropriately sized ring buffer handy.  No allocations will be done.
 
-  \emph{Usage:}
-  \code{mirror(dest)}
+\emph{Usage:}
+\code{mirror(dest)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{dest}:   The destination ring buffer - will be modified by this call.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{dest}:   The destination ring buffer - will be modified by this call.
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{head_offset}}{
-  Nondestructively read the contents of the \code{head} of the buffer, offset by \code{n} entries.
+Nondestructively read the contents of the \code{head} of the buffer, offset by \code{n} entries.
 
-  \emph{Usage:}
-  \code{head_offset(n)}
+\emph{Usage:}
+\code{head_offset(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Head offset.  This moves away from the most recently added item. An offset of 0 reads the most recently added element, 1 reads the element added before that.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Head offset.  This moves away from the most recently added item. An offset of 0 reads the most recently added element, 1 reads the element added before that.
+}
+}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{tail_offset}}{
-  Nondestructively read the contents of the \code{tail} of the buffer, offset by \code{n} entries.
+Nondestructively read the contents of the \code{tail} of the buffer, offset by \code{n} entries.
 
-  \emph{Usage:}
-  \code{tail_offset(n)}
+\emph{Usage:}
+\code{tail_offset(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Tail offset.  This moves away from the oldest item.  An offset of 0 reads the oldest element, 1 reads the element added after that.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Tail offset.  This moves away from the oldest item.  An offset of 0 reads the oldest element, 1 reads the element added after that.
+}
+}
 
-  \emph{Return value}:
-  As for \code{tail} (see \code{head})
+\emph{Return value}:
+As for \code{tail} (see \code{head})
 }
 \item{\code{take_head}}{
-  As for \code{take}, but operating on the head rather than the tail.  This is destructive with respect to the head.
+As for \code{take}, but operating on the head rather than the tail.  This is destructive with respect to the head.
 
-  \emph{Usage:}
-  \code{take_head(n)}
+\emph{Usage:}
+\code{take_head(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Number of elements to take.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Number of elements to take.
+}
+}
 
-  \emph{Return value}:
-  As for \code{take}
+\emph{Return value}:
+As for \code{take}
 }
 \item{\code{read_head}}{
-  As for \code{read}, but operating on the head rather than the tail.  This is not destructive with respect to the tail.
+As for \code{read}, but operating on the head rather than the tail.  This is not destructive with respect to the tail.
 
-  \emph{Usage:}
-  \code{read_head(n)}
+\emph{Usage:}
+\code{read_head(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Number of elements to read.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Number of elements to read.
+}
+}
 
-  \emph{Return value}:
-  As for \code{read}
+\emph{Return value}:
+As for \code{read}
 }
 \item{\code{head_set}}{
-  Set data to the head \emph{without advancing}.  This is useful in cases where the head data will be set and advanced separately (with \code{head_advance}).  This is unlikely to be useful for all users.  It is used extensively in dde (but called from C).
+Set data to the head \emph{without advancing}.  This is useful in cases where the head data will be set and advanced separately (with \code{head_advance}).  This is unlikely to be useful for all users.  It is used extensively in dde (but called from C).
 
-  \emph{Usage:}
-  \code{head_set(data)}
+\emph{Usage:}
+\code{head_set(data)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   Data to set into the head.  For the bytes buffer this must be exactly \code{stride} bytes long, and for the environment buffer it corresponds to a single "element".
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   Data to set into the head.  For the bytes buffer this must be exactly \code{stride} bytes long, and for the environment buffer it corresponds to a single "element".
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{head_data}}{
-  Retrieve the current data stored in the head but not advanced. For many cases this may be junk - if the byte buffer has looped then it will be the bytes that will be overwritten on the next write.  However, when using \code{head_set} it will be the data that have been set into the buffer but not yet committed with \code{head_advance}.
+Retrieve the current data stored in the head but not advanced. For many cases this may be junk - if the byte buffer has looped then it will be the bytes that will be overwritten on the next write.  However, when using \code{head_set} it will be the data that have been set into the buffer but not yet committed with \code{head_advance}.
 
-  \emph{Usage:}
-  \code{head_data()}
+\emph{Usage:}
+\code{head_data()}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{head_advance}}{
-  Shift the head around one position.  This commits any data written by \code{head_set}.
+Shift the head around one position.  This commits any data written by \code{head_set}.
 
-  \emph{Usage:}
-  \code{head_advance()}
+\emph{Usage:}
+\code{head_advance()}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 }
 }

--- a/man/ring_buffer_env.Rd
+++ b/man/ring_buffer_env.Rd
@@ -29,9 +29,8 @@ version of an R \code{\link{list}}.
 \details{
 When pushing objects onto the buffer, you must be careful about
 the \code{iterate} argument.  By default if the object has a
-\code{length()} greater than 1 then \code{$push()} will iterate
-over the object (equivalent to \code{$push(data[[1]],
-iterate=FALSE)}, \code{$push(data[[2]], iterate=FALSE)}, and so
+\code{length()} greater than 1 then \verb{$push()} will iterate
+over the object (equivalent to \verb{$push(data[[1]], iterate=FALSE)}, \verb{$push(data[[2]], iterate=FALSE)}, and so
 on).
 
 For more information and usage examples, see the vignette
@@ -56,391 +55,399 @@ the differences between implementations will be a bit more apparent.
 
 \describe{
 \item{\code{reset}}{
-  Reset the state of the buffer.  This "zeros" the head and tail pointer (and may or may not actually reset the data) so that the buffer can be used as if fresh.
+Reset the state of the buffer.  This "zeros" the head and tail pointer (and may or may not actually reset the data) so that the buffer can be used as if fresh.
 
-  \emph{Usage:}
-  \code{reset(clear = FALSE)}
+\emph{Usage:}
+\code{reset(clear = FALSE)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{clear}:   Logical, indicating if the memory should also be cleared. Generally this is not necessary, but with environment buffers this can let the garbage collector clean up large elements.  For the bytes buffer this zeros the memory.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{clear}:   Logical, indicating if the memory should also be cleared. Generally this is not necessary, but with environment buffers this can let the garbage collector clean up large elements.  For the bytes buffer this zeros the memory.
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{duplicate}}{
-  Clone the ring buffer, creating a copy.  Copies both the underlying data and the position of the head and tail.
+Clone the ring buffer, creating a copy.  Copies both the underlying data and the position of the head and tail.
 
-  \emph{Usage:}
-  \code{duplicate()}
+\emph{Usage:}
+\code{duplicate()}
 
-  \emph{Return value}:
-  A new ring buffer object
+\emph{Return value}:
+A new ring buffer object
 }
 \item{\code{grow}}{
-  Increase the size of the buffer by \code{n} elements.
+Increase the size of the buffer by \code{n} elements.
 
-  \emph{Usage:}
-  \itemize{
-    \item{bytes, typed: \code{grow(n)}}
-    \item{env: \code{grow(n, exact = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{bytes, typed: \code{grow(n)}}
+\item{env: \code{grow(n, exact = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of additional elements that space should be reserved for (scalar non-negative integer).
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of additional elements that space should be reserved for (scalar non-negative integer).
+}
 
-    \item{\code{exact}:   (For bytes buffer only) Logical scalar indicating if growth should increase the size by \emph{exactly} \code{n} elements (if \code{TRUE}) or so that \emph{at least} \code{n} additional elements will fit (growing the buffer geometrically if needed).
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{exact}:   (For bytes buffer only) Logical scalar indicating if growth should increase the size by \\emph\{exactly\} \code{n} elements (if \code{TRUE}) or so that \\emph\{at least\} \code{n} additional elements will fit (growing the buffer geometrically if needed).
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+}
+
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{size}}{
-  Return the capacity (maximum size) of the ring buffer
+Return the capacity (maximum size) of the ring buffer
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{size()}}
-    \item{bytes, typed: \code{size(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{size()}}
+\item{bytes, typed: \code{size(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{bytes_data}}{
-  Return the total size of the data storage used in this object.
+Return the total size of the data storage used in this object.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \emph{(not supported)}}
-    \item{bytes, typed: \code{bytes_data()}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \emph{(not supported)}}
+\item{bytes, typed: \code{bytes_data()}}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{stride}}{
-  Length of each element in the ring buffer, in bytes.  Only implemented (and meaningful) for the bytes buffer; the environment buffer does not support this function as it makes no sense there.
+Length of each element in the ring buffer, in bytes.  Only implemented (and meaningful) for the bytes buffer; the environment buffer does not support this function as it makes no sense there.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \emph{(not supported)}}
-    \item{bytes, typed: \code{stride()}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \emph{(not supported)}}
+\item{bytes, typed: \code{stride()}}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{used}}{
-  Return the amount of space used in the ring buffer.
+Return the amount of space used in the ring buffer.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{used()}}
-    \item{bytes, typed: \code{used(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{used()}}
+\item{bytes, typed: \code{used(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{free}}{
-  Return the amount of space free in the ring buffer.
+Return the amount of space free in the ring buffer.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{free()}}
-    \item{bytes, typed: \code{free(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{free()}}
+\item{bytes, typed: \code{free(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the size should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{is_empty}}{
-  Test if the ring buffer is empty
+Test if the ring buffer is empty
 
-  \emph{Usage:}
-  \code{is_empty()}
+\emph{Usage:}
+\code{is_empty()}
 
-  \emph{Return value}:
-  A scalar logical
+\emph{Return value}:
+A scalar logical
 }
 \item{\code{is_full}}{
-  Test if the ring buffer is full
+Test if the ring buffer is full
 
-  \emph{Usage:}
-  \code{is_full()}
+\emph{Usage:}
+\code{is_full()}
 
-  \emph{Return value}:
-  A scalar logical
+\emph{Return value}:
+A scalar logical
 }
 \item{\code{head_pos}}{
-  Return the number of entries from the "start" of the ring buffer the head is.  This is mostly useful for debugging.
+Return the number of entries from the "start" of the ring buffer the head is.  This is mostly useful for debugging.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{head_pos()}}
-    \item{bytes, typed: \code{head_pos(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{head_pos()}}
+\item{bytes, typed: \code{head_pos(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{tail_pos}}{
-  Return the number of entries from the "start" of the ring buffer the tail is.  This is mostly useful for debugging.
+Return the number of entries from the "start" of the ring buffer the tail is.  This is mostly useful for debugging.
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{tail_pos()}}
-    \item{bytes, typed: \code{tail_pos(bytes = FALSE)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{tail_pos()}}
+\item{bytes, typed: \code{tail_pos(bytes = FALSE)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{bytes}:   (for \code{ring_buffer_bytes} only) Logical, indicating if the position should be returned in bytes (rather than logical entries, which is the default).
+}
+}
 
-  \emph{Return value}:
-  A scalar integer
+\emph{Return value}:
+A scalar integer
 }
 \item{\code{head}}{
-  Return the contents of the head (the most recently written element in the ring buffer).
+Return the contents of the head (the most recently written element in the ring buffer).
 
-  \emph{Usage:}
-  \code{head()}
+\emph{Usage:}
+\code{head()}
 
-  \emph{Return value}:
-  It depends a little here.  For \code{ring_buffer_env} this is a single R object.  For \code{ring_buffer_bytes} it is a raw vector, the same length as the stride of the ring buffer.  For \code{ring_buffer_bytes_typed}, a single R object that has been translated from raw.
+\emph{Return value}:
+It depends a little here.  For \code{ring_buffer_env} this is a single R object.  For \code{ring_buffer_bytes} it is a raw vector, the same length as the stride of the ring buffer.  For \code{ring_buffer_bytes_typed}, a single R object that has been translated from raw.
 }
 \item{\code{tail}}{
-  Return the contents of the tail (the least recently written element in the ring buffer).
+Return the contents of the tail (the least recently written element in the ring buffer).
 
-  \emph{Usage:}
-  \code{tail()}
+\emph{Usage:}
+\code{tail()}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{set}}{
-  Set a number of ring entries to the same value.  The exact behaviour here varies depending on the type of ring buffer.  This function may overflow the ring buffer; in this case the tail will be moved.
+Set a number of ring entries to the same value.  The exact behaviour here varies depending on the type of ring buffer.  This function may overflow the ring buffer; in this case the tail will be moved.
 
-  \emph{Usage:}
-  \code{set(data, n)}
+\emph{Usage:}
+\code{set(data, n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   The data to set each ring element to.  For an environment buffer, this may be any R object.  For a bytes buffer it may be either a single byte (in which case each ring element will be set to that byte, repeated \code{stride} times), or a raw vector of length \code{stride}.
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   The data to set each ring element to.  For an environment buffer, this may be any R object.  For a bytes buffer it may be either a single byte (in which case each ring element will be set to that byte, repeated \code{stride} times), or a raw vector of length \code{stride}.
+}
 
-    \item{\code{n}:   The number of entries to set to \code{data}
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{n}:   The number of entries to set to \code{data}
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  Invisibly returns the number of elements actually written (which may be less than \code{n} if the buffer overflows).  Primarily called for its side effect.
+}
+
+\emph{Return value}:
+Invisibly returns the number of elements actually written (which may be less than \code{n} if the buffer overflows).  Primarily called for its side effect.
 }
 \item{\code{push}}{
-  Push elements onto the ring buffer head.  This may overflow the ring buffer, destroying the oldest elements in the buffer (and moving the position of the tail).
+Push elements onto the ring buffer head.  This may overflow the ring buffer, destroying the oldest elements in the buffer (and moving the position of the tail).
 
-  \emph{Usage:}
-  \itemize{
-    \item{env: \code{push(data, iterate = TRUE)}}
-    \item{bytes, typed: \code{push(data)}}
-  }
+\emph{Usage:}
+\itemize{
+\item{env: \code{push(data, iterate = TRUE)}}
+\item{bytes, typed: \code{push(data)}}
+}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   Data to push onto the ring buffer.  For \code{ring_buffer_bytes}, this must be a raw vector with a length that is a multiple of the buffer stride.  For \code{ring_buffer_bytes_typed} it must be a vector of the appropriate type.  For \code{ring_buffer_env} it may be an arbitrary R object (but see \code{iterate} .
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   Data to push onto the ring buffer.  For \code{ring_buffer_bytes}, this must be a raw vector with a length that is a multiple of the buffer stride.  For \code{ring_buffer_bytes_typed} it must be a vector of the appropriate type.  For \code{ring_buffer_env} it may be an arbitrary R object (but see \code{iterate} .
+}
 
-    \item{\code{iterate}:   For \code{ring_buffer_env} only, changes the behaviour with vectors and lists.  Because each element of a \code{ring_buffer_env} can b an arbitrary R object, for a list \code{x} it is ambiguous if \code{push(x)} should push one object onto the buffer, or \code{length(x)} objects (i.e. equivalent to \code{push(x[[1]])}, \code{push(x[[2]])}, etc.  The \code{iterate} argument switches between interpretations; if \code{TRUE} (the default) the push will iterate over the object using \code{for (el in x)} (with appropriate S3 dispatch).  If \code{iterate = FALSE}, then the entire object is pushed at once, so always updating only by a single element.
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{iterate}:   For \code{ring_buffer_env} only, changes the behaviour with vectors and lists.  Because each element of a \code{ring_buffer_env} can b an arbitrary R object, for a list \code{x} it is ambiguous if \code{push(x)} should push one object onto the buffer, or \code{length(x)} objects (i.e. equivalent to \code{push(x[[1]])}, \code{push(x[[2]])}, etc.  The \code{iterate} argument switches between interpretations; if \code{TRUE} (the default) the push will iterate over the object using \code{for (el in x)} (with appropriate S3 dispatch).  If \code{iterate = FALSE}, then the entire object is pushed at once, so always updating only by a single element.
+\}
+}\if{html}{\out{</div>}}
 
-  \emph{Return value}:
-  For \code{ring_buffer_bytes}, the data invisibly.  For \code{ring_buffer_bytes} and \code{ring_buffer_bytes_typed}, the position of the head pointer (relative to the beginning of the storage region).
+}
+
+\emph{Return value}:
+For \code{ring_buffer_bytes}, the data invisibly.  For \code{ring_buffer_bytes} and \code{ring_buffer_bytes_typed}, the position of the head pointer (relative to the beginning of the storage region).
 }
 \item{\code{take}}{
-  Destructively take elements from the ring buffer.  This consumes from the tail (the least recently added elements).  It is not possibly to underflow the buffer; if more elements are requested than can be supplied then an error will be thrown and the state of the buffer unmodified.
+Destructively take elements from the ring buffer.  This consumes from the tail (the least recently added elements).  It is not possibly to underflow the buffer; if more elements are requested than can be supplied then an error will be thrown and the state of the buffer unmodified.
 
-  \emph{Usage:}
-  \code{take(n)}
+\emph{Usage:}
+\code{take(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of elements to take.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of elements to take.
+}
+}
 
-  \emph{Return value}:
-  For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
+\emph{Return value}:
+For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
 }
 \item{\code{read}}{
-  Nondestructively read elements from the ring buffer.  This is identical to \code{take} except that the state of the buffer is not modified.
+Nondestructively read elements from the ring buffer.  This is identical to \code{take} except that the state of the buffer is not modified.
 
-  \emph{Usage:}
-  \code{read(n)}
+\emph{Usage:}
+\code{read(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   The number of elements to read.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   The number of elements to read.
+}
+}
 
-  \emph{Return value}:
-  For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
+\emph{Return value}:
+For \code{ring_buffer_env} a \code{list} of \code{n} elements. For \code{ring_buffer_bytes}, a raw vector of \code{n * stride} bytes.  For \code{ring_buffer_bytes_typed}, an vector of \code{n} elements of the storage mode of the ring.
 }
 \item{\code{copy}}{
-  Copy from \emph{this} ring buffer into a different ring buffer. This is destructive with respect to both ring buffers; the tail pointer will be moved in this ring buffer as data are taken, and if the destination ring buffer overflows, the tail pointer will be moved too.
+Copy from \emph{this} ring buffer into a different ring buffer. This is destructive with respect to both ring buffers; the tail pointer will be moved in this ring buffer as data are taken, and if the destination ring buffer overflows, the tail pointer will be moved too.
 
-  \emph{Usage:}
-  \code{copy(dest, n)}
+\emph{Usage:}
+\code{copy(dest, n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{dest}:   The destination ring buffer - will be modified by this call.
-    }
+\emph{Arguments:}
+\itemize{
+\item{\code{dest}:   The destination ring buffer - will be modified by this call.
+}
 
-    \item{\code{n}:   The number of elements to copy
-    }
-  }
+\if{html}{\out{<div class="sourceCode">}}\preformatted{\\item\{\code{n}:   The number of elements to copy
+\}
+}\if{html}{\out{</div>}}
+
+}
 }
 \item{\code{mirror}}{
-  Mirror the contents of \emph{this} ring buffer into a different ring buffer.  This differs from \code{copy} in that \emph{this} ring buffer is unaffected and in that \emph{all} of this ring buffer is copied over (including head/tail positions).  This provides an alternative way of duplicating state to \code{duplicate} if you already have an appropriately sized ring buffer handy.  No allocations will be done.
+Mirror the contents of \emph{this} ring buffer into a different ring buffer.  This differs from \code{copy} in that \emph{this} ring buffer is unaffected and in that \emph{all} of this ring buffer is copied over (including head/tail positions).  This provides an alternative way of duplicating state to \code{duplicate} if you already have an appropriately sized ring buffer handy.  No allocations will be done.
 
-  \emph{Usage:}
-  \code{mirror(dest)}
+\emph{Usage:}
+\code{mirror(dest)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{dest}:   The destination ring buffer - will be modified by this call.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{dest}:   The destination ring buffer - will be modified by this call.
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{head_offset}}{
-  Nondestructively read the contents of the \code{head} of the buffer, offset by \code{n} entries.
+Nondestructively read the contents of the \code{head} of the buffer, offset by \code{n} entries.
 
-  \emph{Usage:}
-  \code{head_offset(n)}
+\emph{Usage:}
+\code{head_offset(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Head offset.  This moves away from the most recently added item. An offset of 0 reads the most recently added element, 1 reads the element added before that.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Head offset.  This moves away from the most recently added item. An offset of 0 reads the most recently added element, 1 reads the element added before that.
+}
+}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{tail_offset}}{
-  Nondestructively read the contents of the \code{tail} of the buffer, offset by \code{n} entries.
+Nondestructively read the contents of the \code{tail} of the buffer, offset by \code{n} entries.
 
-  \emph{Usage:}
-  \code{tail_offset(n)}
+\emph{Usage:}
+\code{tail_offset(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Tail offset.  This moves away from the oldest item.  An offset of 0 reads the oldest element, 1 reads the element added after that.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Tail offset.  This moves away from the oldest item.  An offset of 0 reads the oldest element, 1 reads the element added after that.
+}
+}
 
-  \emph{Return value}:
-  As for \code{tail} (see \code{head})
+\emph{Return value}:
+As for \code{tail} (see \code{head})
 }
 \item{\code{take_head}}{
-  As for \code{take}, but operating on the head rather than the tail.  This is destructive with respect to the head.
+As for \code{take}, but operating on the head rather than the tail.  This is destructive with respect to the head.
 
-  \emph{Usage:}
-  \code{take_head(n)}
+\emph{Usage:}
+\code{take_head(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Number of elements to take.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Number of elements to take.
+}
+}
 
-  \emph{Return value}:
-  As for \code{take}
+\emph{Return value}:
+As for \code{take}
 }
 \item{\code{read_head}}{
-  As for \code{read}, but operating on the head rather than the tail.  This is not destructive with respect to the tail.
+As for \code{read}, but operating on the head rather than the tail.  This is not destructive with respect to the tail.
 
-  \emph{Usage:}
-  \code{read_head(n)}
+\emph{Usage:}
+\code{read_head(n)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{n}:   Number of elements to read.
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{n}:   Number of elements to read.
+}
+}
 
-  \emph{Return value}:
-  As for \code{read}
+\emph{Return value}:
+As for \code{read}
 }
 \item{\code{head_set}}{
-  Set data to the head \emph{without advancing}.  This is useful in cases where the head data will be set and advanced separately (with \code{head_advance}).  This is unlikely to be useful for all users.  It is used extensively in dde (but called from C).
+Set data to the head \emph{without advancing}.  This is useful in cases where the head data will be set and advanced separately (with \code{head_advance}).  This is unlikely to be useful for all users.  It is used extensively in dde (but called from C).
 
-  \emph{Usage:}
-  \code{head_set(data)}
+\emph{Usage:}
+\code{head_set(data)}
 
-  \emph{Arguments:}
-  \itemize{
-    \item{\code{data}:   Data to set into the head.  For the bytes buffer this must be exactly \code{stride} bytes long, and for the environment buffer it corresponds to a single "element".
-    }
-  }
+\emph{Arguments:}
+\itemize{
+\item{\code{data}:   Data to set into the head.  For the bytes buffer this must be exactly \code{stride} bytes long, and for the environment buffer it corresponds to a single "element".
+}
+}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 \item{\code{head_data}}{
-  Retrieve the current data stored in the head but not advanced. For many cases this may be junk - if the byte buffer has looped then it will be the bytes that will be overwritten on the next write.  However, when using \code{head_set} it will be the data that have been set into the buffer but not yet committed with \code{head_advance}.
+Retrieve the current data stored in the head but not advanced. For many cases this may be junk - if the byte buffer has looped then it will be the bytes that will be overwritten on the next write.  However, when using \code{head_set} it will be the data that have been set into the buffer but not yet committed with \code{head_advance}.
 
-  \emph{Usage:}
-  \code{head_data()}
+\emph{Usage:}
+\code{head_data()}
 
-  \emph{Return value}:
-  As for \code{head}
+\emph{Return value}:
+As for \code{head}
 }
 \item{\code{head_advance}}{
-  Shift the head around one position.  This commits any data written by \code{head_set}.
+Shift the head around one position.  This commits any data written by \code{head_set}.
 
-  \emph{Usage:}
-  \code{head_advance()}
+\emph{Usage:}
+\code{head_advance()}
 
-  \emph{Return value}:
-  Nothing; called for the side effect only.
+\emph{Return value}:
+Nothing; called for the side effect only.
 }
 }
 }

--- a/src/ring_r.c
+++ b/src/ring_r.c
@@ -137,7 +137,7 @@ SEXP R_ring_buffer_push(SEXP extPtr, SEXP r_data) {
   ring_buffer *buffer = ring_buffer_get(extPtr, true);
   size_t len = LENGTH(r_data), stride = buffer->stride;
   if (len % stride != 0) {
-    Rf_error("Incorrect size data (%d bytes); expected multiple of %d bytes",
+    Rf_error("Incorrect size data (%zu bytes); expected multiple of %zu bytes",
              len, stride);
   }
   size_t n = len / stride;
@@ -233,7 +233,7 @@ SEXP R_ring_buffer_copy(SEXP srcPtr, SEXP destPtr, SEXP r_n) {
     if (src == dest) {
       Rf_error("Can't copy a buffer into itself");
     } else if (src->stride != dest->stride) {
-      Rf_error("Can't copy as buffers differ in their stride (%d vs %d)",
+      Rf_error("Can't copy as buffers differ in their stride (%zu vs %zu)",
                src->stride, dest->stride);
     } else {
       throw_underflow(src, n);
@@ -250,10 +250,10 @@ SEXP R_ring_buffer_mirror(SEXP srcPtr, SEXP destPtr) {
     if (src == dest) {
       Rf_error("Can't mirror a buffer into itself");
     } else if (src->stride != dest->stride) {
-      Rf_error("Can't mirror as buffers differ in their stride (%d vs %d)",
+      Rf_error("Can't mirror as buffers differ in their stride (%zu vs %zu)",
                src->stride, dest->stride);
     } else if (src->size != dest->size) {
-      Rf_error("Can't mirror as buffers differ in their size (%d vs %d)",
+      Rf_error("Can't mirror as buffers differ in their size (%zu vs %zu)",
                src->size, dest->size);
     } else {
       Rf_error("Unknown error [ring bug]"); // #nocov
@@ -266,7 +266,7 @@ SEXP R_ring_buffer_head_set(SEXP extPtr, SEXP r_data) {
   ring_buffer *buffer = ring_buffer_get(extPtr, true);
   const size_t len = LENGTH(r_data), stride = buffer->stride;
   if (len != stride) {
-    Rf_error("Incorrect size data (%d bytes); expected exactly %d bytes",
+    Rf_error("Incorrect size data (%zu bytes); expected exactly %zu bytes",
              len, stride);
   }
   const data_t *data = get_raw(r_data);
@@ -357,7 +357,7 @@ SEXP scalar_size_sexp(size_t x) {
 }
 
 void throw_underflow(ring_buffer *buffer, size_t n) {
-  Rf_error("Buffer underflow (requested %d elements but %d available)",
+  Rf_error("Buffer underflow (requested %zu elements but %zu available)",
            n, ring_buffer_used(buffer, false));
 } // #nocov
 

--- a/src/ring_r.c
+++ b/src/ring_r.c
@@ -137,8 +137,7 @@ SEXP R_ring_buffer_push(SEXP extPtr, SEXP r_data) {
   ring_buffer *buffer = ring_buffer_get(extPtr, true);
   size_t len = LENGTH(r_data), stride = buffer->stride;
   if (len % stride != 0) {
-    Rf_error("Incorrect size data (%zu bytes); expected multiple of %zu bytes",
-             len, stride);
+    Rf_error("Incorrect size data; expected multiple of %d bytes", (int)stride);
   }
   size_t n = len / stride;
   const data_t *data = get_raw(r_data);
@@ -233,8 +232,8 @@ SEXP R_ring_buffer_copy(SEXP srcPtr, SEXP destPtr, SEXP r_n) {
     if (src == dest) {
       Rf_error("Can't copy a buffer into itself");
     } else if (src->stride != dest->stride) {
-      Rf_error("Can't copy as buffers differ in their stride (%zu vs %zu)",
-               src->stride, dest->stride);
+      Rf_error("Can't copy as buffers differ in their stride (%d vs %d)",
+               (int)src->stride, (int)dest->stride);
     } else {
       throw_underflow(src, n);
     }
@@ -250,11 +249,11 @@ SEXP R_ring_buffer_mirror(SEXP srcPtr, SEXP destPtr) {
     if (src == dest) {
       Rf_error("Can't mirror a buffer into itself");
     } else if (src->stride != dest->stride) {
-      Rf_error("Can't mirror as buffers differ in their stride (%zu vs %zu)",
-               src->stride, dest->stride);
+      Rf_error("Can't mirror as buffers differ in their stride (%d vs %d)",
+               (int)src->stride, (int)dest->stride);
     } else if (src->size != dest->size) {
-      Rf_error("Can't mirror as buffers differ in their size (%zu vs %zu)",
-               src->size, dest->size);
+      Rf_error("Can't mirror as buffers differ in their size (%d vs %d)",
+               (int)src->size, (int)dest->size);
     } else {
       Rf_error("Unknown error [ring bug]"); // #nocov
     }
@@ -266,8 +265,8 @@ SEXP R_ring_buffer_head_set(SEXP extPtr, SEXP r_data) {
   ring_buffer *buffer = ring_buffer_get(extPtr, true);
   const size_t len = LENGTH(r_data), stride = buffer->stride;
   if (len != stride) {
-    Rf_error("Incorrect size data (%zu bytes); expected exactly %zu bytes",
-             len, stride);
+    Rf_error("Incorrect size data (%d bytes); expected exactly %d bytes",
+             (int)len, (int)stride);
   }
   const data_t *data = get_raw(r_data);
   memcpy(buffer->head, data, stride);
@@ -357,8 +356,8 @@ SEXP scalar_size_sexp(size_t x) {
 }
 
 void throw_underflow(ring_buffer *buffer, size_t n) {
-  Rf_error("Buffer underflow (requested %zu elements but %zu available)",
-           n, ring_buffer_used(buffer, false));
+  Rf_error("Buffer underflow (requested %d elements but %d available)",
+           (int)n, (int)ring_buffer_used(buffer, false));
 } // #nocov
 
 const data_t * get_raw(SEXP data) {


### PR DESCRIPTION
Cran fix, as always two weeks or the package gets it...

Warnings here: https://cran.r-project.org/web/checks/check_results_ring.html

<details>
<summary>Details</summary>

Check Details
Version: 1.0.4
Check: whether package can be installed
Result: WARN 
  Found the following significant warnings:
    ../inst/include/ring/ring.c:561:16: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ../inst/include/ring/ring.c:561:19: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:140:14: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:140:19: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:236:16: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:236:29: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:253:16: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:253:29: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:256:16: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:256:27: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:269:14: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:269:19: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:360:12: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:360:15: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  See ‘/home/hornik/tmp/R.check/r-devel-clang/Work/PKGS/ring.Rcheck/00install.out’ for details.
  * used C compiler: ‘Debian clang version 17.0.5 (1)’
Flavor: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/ring-00check.html)

Version: 1.0.4
Check: whether package can be installed
Result: WARN 
  Found the following significant warnings:
    ../inst/include/ring/ring.c:560:42: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ../inst/include/ring/ring.c:560:59: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:139:37: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:139:69: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:235:64: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:235:70: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:252:66: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:252:72: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:255:64: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:255:70: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:268:37: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:268:65: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:359:42: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
    ring_r.c:359:58: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  See ‘/home/hornik/tmp/R.check/r-devel-gcc/Work/PKGS/ring.Rcheck/00install.out’ for details.
  * used C compiler: ‘gcc-13 (Debian 13.2.0-5) 13.2.0’
Flavor: [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/ring-00check.html)

Version: 1.0.4
Check: whether package can be installed
Result: WARN 
  Found the following significant warnings:
    ../inst/include/ring/ring.c:561:16: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ../inst/include/ring/ring.c:561:19: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:140:14: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:140:19: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:236:16: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:236:29: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:253:16: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:253:29: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:256:16: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:256:27: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:269:14: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:269:19: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:360:12: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    ring_r.c:360:15: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  See ‘/data/gannet/ripley/R/packages/tests-clang/ring.Rcheck/00install.out’ for details.
  * used C compiler: ‘clang version 17.0.5’
Flavor: [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/ring-00check.html)

Version: 1.0.4
Check: whether package can be installed
Result: WARN 
  Found the following significant warnings:
    ../inst/include/ring/ring.c:560:42: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ../inst/include/ring/ring.c:560:59: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:139:37: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:139:69: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:235:64: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:235:70: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:252:66: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:252:72: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:255:64: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:255:70: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:268:37: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:268:65: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:359:42: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
    ring_r.c:359:58: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
  See ‘/data/gannet/ripley/R/packages/tests-devel/ring.Rcheck/00install.out’ for details.
  * used C compiler: ‘gcc-13 (GCC) 13.2.0’
Flavor: [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/ring-00check.html)

Version: 1.0.4
Check: whether package can be installed
Result: WARN 
  Found the following significant warnings:
    ../inst/include/ring/ring.c:560:42: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ../inst/include/ring/ring.c:560:59: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:139:37: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:139:69: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:235:64: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:235:70: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:252:66: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:252:72: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:255:64: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:255:70: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:268:37: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:268:65: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:359:42: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
    ring_r.c:359:58: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
  See 'd:/Rcompile/CRANpkg/local/4.4/ring.Rcheck/00install.out' for details.
  * used C compiler: 'gcc.exe (GCC) 12.3.0'
Flavor: [r-devel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/ring-00check.html)

</details>

Passing on win builder: https://win-builder.r-project.org/fdhYlvgV9sEA/